### PR TITLE
Settled VFS locking mechanism.

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -1,0 +1,4 @@
+# Important mechanisms
+
+## Directory name length checks
+In L2, every time a directory/file is made or renamed its name (UTF-8 string) must be checked to fit within a 16-bit range.

--- a/src/L1/Filesystem.ts
+++ b/src/L1/Filesystem.ts
@@ -189,6 +189,7 @@ export default class Filesystem {
                     if (closeError) return IBFSError.eav('L1_FS_ADSPACE_SCAN', null, closeError)
 
                     const dirObj = VFS.dir(address, size) as TDirectory
+                    dirObj.perms = dir.users
 
                     for (const filename in dir.children) {
                         if (Object.prototype.hasOwnProperty.call(dir.children, filename)) {

--- a/src/L1/caching/InstanceRegistry.ts
+++ b/src/L1/caching/InstanceRegistry.ts
@@ -96,8 +96,8 @@ export default class InstanceRegistry<Key, Ref extends object> {
         const meta = this._meta.get(key)
 
         if (meta) {
-            meta!.refCount--
-            if (meta!.refCount <= 0) {
+            meta.refCount--
+            if (meta.refCount <= 0) {
                 this._refs.delete(key)
                 this._meta.delete(key)
                 this._fr.unregister(meta!.uToken)
@@ -108,7 +108,7 @@ export default class InstanceRegistry<Key, Ref extends object> {
         return false
 
     }
-
+    
     /**
      * Returns the stored instance reference.
      * @param key Key used to access the object.

--- a/src/L1/file/FileBlockMap.ts
+++ b/src/L1/file/FileBlockMap.ts
@@ -434,7 +434,7 @@ export default class FileBlockMap {
     // Setters ---------------------------------------------------------------------------------------------------------
 
     /**
-     * Updates the metadata in the file's root block.
+     * Updates the metadata in the file's head block.
      */
     public async setMetadata(metadata: TChangeMetadata): T.XEavSA<"L1_FBM_SETMETA"> {
 

--- a/src/L1/file/FileHandle.ts
+++ b/src/L1/file/FileHandle.ts
@@ -45,6 +45,7 @@ export default class FileHandle extends EventEmitter {
     /** File's top-level block map.                        */ public declare readonly   fbm:                  FileBlockMap
     /** Original length of the file data.                  */ public declare readonly   originalLength:       number
 
+    /** The mode the handle was opened with.               */ public  declare readonly mode:                  'r' | 'w' | 'rw'
     /** Whether the file is currently open for reading.    */ private declare readonly _read:                 boolean
     /** Whether the file is currently open for writing.    */ private declare readonly _write:                boolean
     /** Whether writes be appended to the end of the file. */ private declare readonly _append:               boolean
@@ -76,6 +77,7 @@ export default class FileHandle extends EventEmitter {
             ;(self as any)._write          = ['rw', 'w'].includes(options.mode)
             ;(self as any)._append         = options.append   || false
             ;(self as any)._truncate       = options.truncate || false
+            ;(self as any).mode            = options.mode
 
             // Load FBM ---------------------------
             const [fbmError, fbm] = await FileBlockMap.open(options)

--- a/src/L1/file/FileHandle.ts
+++ b/src/L1/file/FileHandle.ts
@@ -26,11 +26,12 @@ export interface TFHOpenOptions extends TFBMOpenOptions {
     /** Whether the file should be truncated on open.                */ truncate?: boolean
 }
 
+type Events = 'requests-close' | 'close'
+
 // Exports =============================================================================================================
 
 export const FINALIZE_HANDLE_CLOSE = Symbol('finalize_handle_close')
 
-type Events = 'requests-close' | 'final-close'
 export default interface FileHandle extends EventEmitter {
     once(event: Events, listener: () => void): this
     on  (event: Events, listener: () => void): this
@@ -120,12 +121,18 @@ export default class FileHandle extends EventEmitter {
 
     // Lifecycle -------------------------------------------------------------------------------------------------------
 
+    /**
+     * Closes the file handle.  
+     * Requires all the underlying streams and I/O operations to be finished and closed before closing the handle.  
+     * Underlying streams are not force-closed on handle close because specifically read-only streams are reused
+     * across multiple concurrent users/consumers.
+     */
     public async close(): T.XEavSA<'L1_FH_CLOSE'> {
         try {
 
             // Fail silently if the file is already closed or is still busy.
             if (!this._isOpen) return new IBFSError('L1_FH_CLOSE', 'The handle is already closed')
-            if (this._isBusy()) return new IBFSError('L1_FH_CLOSE', `Can't close the handle because it's busy. Wait for`
+            if (this.isBusy()) return new IBFSError('L1_FH_CLOSE', `Can't close the handle because it's busy. Wait for`
                 +` all read/write activity to finish or terminate all active streams before closing.`)
 
             this.emit('requests-close')
@@ -138,7 +145,7 @@ export default class FileHandle extends EventEmitter {
 
     public [FINALIZE_HANDLE_CLOSE]() {
         this._isOpen = false
-        this.emit('final-close')
+        this.emit('close')
     }
 
     // I/O methods -----------------------------------------------------------------------------------------------------
@@ -153,8 +160,8 @@ export default class FileHandle extends EventEmitter {
     public async readFile(integrity = true): T.XEavA<Buffer, 'L1_FH_READ'|'L1_FH_READ_MODE'|'L1_FH_BUSY'> {
         try {
 
-            if (!this._read) return IBFSError.eav('L1_FH_READ_MODE')
-            if (this._isBusy()) return IBFSError.eav('L1_FH_BUSY')
+            if (!this._read)          return IBFSError.eav('L1_FH_READ_MODE')
+            if (this.isBusyWriting()) return IBFSError.eav('L1_FH_BUSY')
 
             const fs = this.fbm.containingFilesystem
             const memory = Memory.allocUnsafe(fs.volume.bs.DATA_CONTENT_SIZE * this.fbm.length)
@@ -181,8 +188,8 @@ export default class FileHandle extends EventEmitter {
     public async read(offset: number, length: number, integrity = true): T.XEavA<Buffer, 'L1_FH_READ'|'L1_FH_READ_MODE'|"L1_FH_BUSY">  {
         try {
 
-            if (!this._read) return IBFSError.eav('L1_FH_READ_MODE')
-            if (this._isBusy()) return IBFSError.eav('L1_FH_BUSY')
+            if (!this._read)          return IBFSError.eav('L1_FH_READ_MODE')
+            if (this.isBusyWriting()) return IBFSError.eav('L1_FH_BUSY')
         
             const memory = Memory.allocUnsafe(length)
 
@@ -206,8 +213,8 @@ export default class FileHandle extends EventEmitter {
     public async writeFile(data: Buffer): T.XEavSA<'L1_FH_WRITE_FILE'|'L1_FH_WRITE_MODE'|'L1_FH_BUSY'> {
         try {
 
-            if (!this._write) return new IBFSError('L1_FH_WRITE_MODE')
-            if (this._isBusy()) return new IBFSError('L1_FH_BUSY')
+            if (!this._write)  return new IBFSError('L1_FH_WRITE_MODE')
+            if (this.isBusy()) return new IBFSError('L1_FH_BUSY')
 
             const [lenError, fileLength] = await this.getFileLength()
             if (lenError) return new IBFSError('L1_FH_WRITE_FILE', null, lenError)
@@ -240,8 +247,8 @@ export default class FileHandle extends EventEmitter {
     public async write(data: Buffer, offset: number): T.XEavSA<'L1_FH_WRITE'|'L1_FH_WRITE_MODE'|'L1_FH_BUSY'> {
         try {
 
-            if (!this._write) return new IBFSError('L1_FH_WRITE_MODE')
-            if (this._isBusy()) return new IBFSError('L1_FH_BUSY')
+            if (!this._write)  return new IBFSError('L1_FH_WRITE_MODE')
+            if (this.isBusy()) return new IBFSError('L1_FH_BUSY')
 
             const [wsError, ws] = await this.createWriteStream({ offset })
             if (wsError) return new IBFSError('L1_FH_WRITE', null, wsError)
@@ -262,8 +269,8 @@ export default class FileHandle extends EventEmitter {
     public async append(data: Buffer): T.XEavSA<'L1_FH_APPEND'|'L1_FH_WRITE_MODE'|'L1_FH_BUSY'> {
         try {
 
-            if (!this._write) return new IBFSError('L1_FH_WRITE_MODE')
-            if (this._isBusy()) return new IBFSError('L1_FH_BUSY')
+            if (!this._write)  return new IBFSError('L1_FH_WRITE_MODE')
+            if (this.isBusy()) return new IBFSError('L1_FH_BUSY')
 
             const [lenError, fileLength] = await this.getFileLength()
             if (lenError) return new IBFSError('L1_FH_APPEND', null, lenError)
@@ -287,8 +294,8 @@ export default class FileHandle extends EventEmitter {
      */
     public async truncate(length: number): T.XEavSA<'L1_FH_TRUNC'|'L1_FH_TRUNC_OUTRANGE'|'L1_FH_TRUNC_MODE'|'L1_FH_BUSY'> {
 
-        if (!this._write) return new IBFSError('L1_FH_TRUNC_MODE')
-        if (this._isBusy()) return new IBFSError('L1_FH_BUSY')
+        if (!this._write)  return new IBFSError('L1_FH_TRUNC_MODE')
+        if (this.isBusy()) return new IBFSError('L1_FH_BUSY')
 
         const [lenError, fileLength] = await this.getFileLength()
         if (lenError) return new IBFSError('L1_FH_TRUNC', null, lenError)
@@ -323,9 +330,9 @@ export default class FileHandle extends EventEmitter {
     public async readAsDir(integrity = true): T.XEavA<TDirectory, 'L1_FH_DIR_READ'|'L1_FH_READ_MODE'|'L1_FH_BUSY'|'L1_FH_DIR_READ_TYPE'> {
         try {
 
-            if (this.type !== 'DIR') return IBFSError.eav('L1_FH_DIR_READ_TYPE')
-            if (!this._read) return IBFSError.eav('L1_FH_READ_MODE')
-            if (this._isBusy()) return IBFSError.eav('L1_FH_BUSY')
+            if (this.type !== 'DIR')  return IBFSError.eav('L1_FH_DIR_READ_TYPE')
+            if (!this._read)          return IBFSError.eav('L1_FH_READ_MODE')
+            if (this.isBusyWriting()) return IBFSError.eav('L1_FH_BUSY')
 
             const fs = this.fbm.containingFilesystem
             const memory = Memory.allocUnsafe(fs.volume.bs.DATA_CONTENT_SIZE * this.fbm.length)
@@ -353,8 +360,8 @@ export default class FileHandle extends EventEmitter {
         try {
 
             if (this.type !== 'DIR') return new IBFSError('L1_FH_DIR_WRITE_TYPE')
-            if (!this._write) return new IBFSError('L1_FH_WRITE_MODE')
-            if (this._isBusy()) return new IBFSError('L1_FH_BUSY')
+            if (!this._write)        return new IBFSError('L1_FH_WRITE_MODE')
+            if (this.isBusy())       return new IBFSError('L1_FH_BUSY')
 
             const data = DirectoryTable.serialize(dir)
 
@@ -390,8 +397,8 @@ export default class FileHandle extends EventEmitter {
         T.XEavA<FileReadStream, 'L1_FH_READ_STREAM'|"L1_FH_READ_STREAM_BUFFER"|'L1_FH_READ_MODE'|'L1_FH_READ_STREAM_EXREF'> {
         try {
 
-            if (!this._read) return IBFSError.eav('L1_FH_READ_MODE')
-            if (this._ws.activeCount() > 0) return IBFSError.eav('L1_FH_READ_STREAM_EXREF')
+            if (!this._read)          return IBFSError.eav('L1_FH_READ_MODE')
+            if (this.isBusyWriting()) return IBFSError.eav('L1_FH_READ_STREAM_EXREF')
 
             const [error, stream] = await FileReadStream.open(this, options)
             if (error) return IBFSError.eav('L1_FH_READ_STREAM', null, error)
@@ -413,9 +420,8 @@ export default class FileHandle extends EventEmitter {
     public async createWriteStream(options: TFWSOptions = {}): T.XEavA<FileWriteStream, 'L1_FH_WRITE_STREAM'|'L1_FH_WRITE_STREAM_EXREF'|'L1_FH_WRITE_MODE'> {
         try {
 
-            if (!this._write) return IBFSError.eav('L1_FH_WRITE_MODE')
-            if (this._ws.activeCount() > 0) return IBFSError.eav('L1_FH_WRITE_STREAM_EXREF')
-            if (this._rs.activeCount() > 0) return IBFSError.eav('L1_FH_WRITE_STREAM_EXREF')
+            if (!this._write)  return IBFSError.eav('L1_FH_WRITE_MODE')
+            if (this.isBusy()) return IBFSError.eav('L1_FH_WRITE_STREAM_EXREF')
 
             let offset = options.offset
             if (this._append) {
@@ -445,7 +451,7 @@ export default class FileHandle extends EventEmitter {
 
         if (stream instanceof FileWriteStream) {
             const streamMeta = { 
-                "File address": stream._handle.fbm.startingAddress, 
+                "File address":     stream._handle.fbm.startingAddress, 
                 "Commit frequency": stream._fbmCommitFrequency 
             }
             this._ws.addRef('stream', stream, streamMeta)
@@ -456,7 +462,7 @@ export default class FileHandle extends EventEmitter {
         else {
             const streamMeta = { 
                 "File address": stream._handle.fbm.startingAddress, 
-                "Integrity": stream._integrity
+                "Integrity":    stream._integrity
             }
             const ctr = this._ctr++
             this._rs.addRef(ctr, stream, streamMeta)
@@ -468,11 +474,18 @@ export default class FileHandle extends EventEmitter {
     }
 
     /**
-     * Returns whether the file handle is currently in use.
+     * Returns true if the file handle is in use, either reading or writing.
      */
-    private _isBusy(): boolean {
+    private isBusy(): boolean {
         return this._rs.activeCount() > 0 || 
                this._ws.activeCount() > 0
+    }
+
+    /**
+     * Returns true if the file handle is in use writing.
+     */
+    public isBusyWriting(): boolean {
+        return this._ws.activeCount() > 0
     }
 
     // Helpers ---------------------------------------------------------------------------------------------------------

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -2,12 +2,17 @@
 
 import type * as T from '../../types.js'
 import IBFSError from '../errors/IBFSError.js'
-import Filesystem, { TFSInit } from '../L1/Filesystem.js'
+import DirectoryTable from '../L1/directory/DirectoryTables.js'
+import FileHandle from '../L1/file/FileHandle.js'
+import Filesystem, { TFSInit, TFSOpenFile } from '../L1/Filesystem.js'
+import ssc from '../misc/safeShallowCopy.js'
 import VFS, { TDirectory } from './VirtualFilesystem.js'
 
 // Types ===============================================================================================================
 
-export interface TNSInit extends TFSInit {}
+export interface TNSInit extends TFSInit {
+    /** The group of root users allowed to manage the filesystem. */ rootGroup: string
+}
 
 // Exports =============================================================================================================
 
@@ -29,9 +34,28 @@ export default class Namespace {
         try {
             
             // Create filesystem -----------------------------------------
-            const fsError = await Filesystem.createEmptyFilesystem(options)
-            if (fsError) return new IBFSError('L2_NS_CREATE', null, fsError)
-            
+            const createError = await Filesystem.createEmptyFilesystem(options)
+            if (createError) return new IBFSError('L2_NS_CREATE', null, createError, ssc(options, ['aesKey']))
+
+            // Create root group -----------------------------------------
+
+            let vfs: TDirectory
+            const [fsError, fs] = await Filesystem.open(options.fileLocation, options.aesKey, (dirTree) => vfs = dirTree as TDirectory)
+            if (fsError) return new IBFSError('L2_NS_CREATE', null, fsError, ssc(options, ['aesKey']))
+
+            const [openError, handle] = await fs.open({ fileAddress: vfs!.address, mode: 'rw' })
+            if (openError) return new IBFSError('L2_NS_CREATE', null, openError, ssc(options, ['aesKey']))
+
+            const writeError = await handle.writeAsDir({
+                children: {},
+                users: { [options.rootGroup]: 4 },
+                meta: {}
+            })
+            if (writeError) return new IBFSError('L2_NS_CREATE', null, writeError, ssc(options, ['aesKey']))
+
+            const hc = await handle.close()
+            if (hc) return new IBFSError('L2_NS_CREATE', null, hc, ssc(options, ['aesKey']))
+
         } 
         catch (error) {
             return new IBFSError('L2_NS_CREATE', null, error as Error)
@@ -59,6 +83,45 @@ export default class Namespace {
         } 
         catch (error) {
             return IBFSError.eav('L2_NS_OPEN', null, error as Error)
+        }
+    }
+
+    // IO methods ------------------------------------------------------------------------------------------------------
+
+    public async open(path: string, group: string, options: Omit<TFSOpenFile, 'fileAddress'>): T.XEavA<FileHandle, 'L2_NS_OPEN_FILE' | 'L2_NS_NO_PERM' | 'L2_NS_LOCKED'> {
+        try {
+
+            const isDisallowed = options.mode === 'r'
+                ? this.vfs.canReadNode(path, group)
+                : this.vfs.canWriteNode(path, group)
+
+            if (isDisallowed) return IBFSError.eav('L2_NS_OPEN_FILE', null, isDisallowed, { path, group, options })
+
+            const [resolveError, vfsNode] = this.vfs.resolve(path)
+            if (resolveError) return IBFSError.eav('L2_NS_OPEN_FILE', null, resolveError, { path, group, options })
+
+            const handle = vfsNode.lock && vfsNode.lock.deref()
+
+            if (!handle) {
+
+                const [openError, handle] = await this.fs.open({ fileAddress: vfsNode.address, ...options })
+                if (openError) return IBFSError.eav('L2_NS_OPEN_FILE', null, openError, { path, group, options })
+
+                vfsNode.lock = new WeakRef(handle)
+                handle.on('final-close', () => vfsNode.lock = null)
+
+                return [null, handle]
+
+            }
+
+            else {
+                if (options.mode === 'r' && handle.mode === 'r') return [null, handle]
+                else return IBFSError.eav('L2_NS_LOCKED', null, null, { path, group, options })
+            }
+            
+        } 
+        catch (error) {
+            return IBFSError.eav('L2_NS_OPEN_FILE', null, error as Error, { path, group, options })
         }
     }
 

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -2,7 +2,6 @@
 
 import type * as T from '../../types.js'
 import IBFSError from '../errors/IBFSError.js'
-import DirectoryTable from '../L1/directory/DirectoryTables.js'
 import FileHandle from '../L1/file/FileHandle.js'
 import Filesystem, { TFSInit, TFSOpenFile } from '../L1/Filesystem.js'
 import ssc from '../misc/safeShallowCopy.js'
@@ -12,6 +11,24 @@ import VFS, { TDirectory } from './VirtualFilesystem.js'
 
 export interface TNSInit extends TFSInit {
     /** The group of root users allowed to manage the filesystem. */ rootGroup: string
+}
+
+// Base options --------------------------------------------------------------------------------------------------------
+
+interface BaseReadOptions {
+    /** Whether to perform data integrity checks during reads. */ integrity?: boolean
+}
+
+export interface TNSReadOptions extends BaseReadOptions {
+    /** Offset from start of the file to begin reading from. */ offset: number
+    /** Number of bytes to read from the offset.             */ length: number
+}
+
+export interface TNSReadFileOptions extends BaseReadOptions {}
+
+export interface TNSOpenReadStreamOptions extends BaseReadOptions {
+    /** Offset from start of the file to begin reading from. */ offset: number
+    /** Number of bytes to read from the offset.             */ length: number
 }
 
 // Exports =============================================================================================================
@@ -108,7 +125,7 @@ export default class Namespace {
                 if (openError) return IBFSError.eav('L2_NS_OPEN_FILE', null, openError, { path, group, options })
 
                 vfsNode.lock = new WeakRef(handle)
-                handle.on('final-close', () => vfsNode.lock = null)
+                handle.on('close', () => vfsNode.lock = null)
 
                 return [null, handle]
 
@@ -124,5 +141,13 @@ export default class Namespace {
             return IBFSError.eav('L2_NS_OPEN_FILE', null, error as Error, { path, group, options })
         }
     }
+
+    public async read(path: string, group: string, options: TNSReadOptions) {}
+
+    public async readFile(path: string, group: string, options?: TNSReadFileOptions) {}
+
+    public async openReadStream(path: string, group: string, options?: TNSOpenReadStreamOptions) {}
+
+
 
 }

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -9,6 +9,7 @@ import type { TPermLevel  } from '../L1/directory/DirectoryTables.js'
 
 import np from 'node:path'
 import IBFSError from '../errors/IBFSError.js'
+import FileHandle from '../L1/file/FileHandle.js'
 
 // Types ===============================================================================================================
 
@@ -18,12 +19,14 @@ export interface TDirectory {
     /** Physical address of the directory head block. */ address:   number
     /** User permissions inside the directory         */ perms:     Record<string, TPermLevel>
     /** Children files and subdirectories.            */ children:  Record<string, TNode>
+    /** The handle that's currently holding the lock. */ lock:      WeakRef<FileHandle> | null
 }
 
 export interface TFile {
     /** Type of the file structure.                   */ type:      'FILE'
     /** Total size of the file's contents.            */ size:      number
     /** Physical address of the file head block.      */ address:   Number
+    /** The handle that's currently holding the lock. */ lock:      WeakRef<FileHandle> | null
 }
 
 export type TNode = TDirectory | TFile
@@ -49,7 +52,8 @@ export default class VFS {
         return {
             type: 'FILE',
             size,
-            address
+            address,
+            lock: null
         }
     }
 
@@ -59,7 +63,8 @@ export default class VFS {
             size,
             address,
             perms: {},
-            children: {}
+            children: {},
+            lock: null
         }
     }
 
@@ -106,15 +111,16 @@ export default class VFS {
         size: 0,
         address: 0,
         perms: {},
-        children: {}
+        children: {},
+        lock: null
     }
 
     // Methods ---------------------------------------------------------------------------------------------------------
 
     /**
-     * Resolves the path to a virtual node.
-     * Use only for referencing VFS nodes for use in other private methods.
-     * This function does not not perform access control checks.
+     * Resolves the path to a virtual node.  
+     * Use only for referencing VFS nodes for use in other private methods.  
+     * This function does not not perform access control checks.  
      * @param path Path to the node to be resolved.
      * @returns [error, node]
      */
@@ -130,6 +136,29 @@ export default class VFS {
         }
 
         return [null, current]
+    }
+
+    /**
+     * Resolves the path to a virtual node's parent directory.  
+     * Use only for referencing VFS nodes for use in other private methods.  
+     * This function does not not perform access control checks.  
+     * @param path Path to the node to be resolved.
+     * @returns [error, node]
+     */
+    public resolveParent(path: string): T.XEav<TDirectory, 'L2_VFS_BAD_PATH'> {
+        
+        let current: TNode = this.tree
+        const { parts, dest } = VFS.normalizeAndSplit(path)
+
+        if (!dest) return IBFSError.eav('L2_VFS_BAD_PATH', `Can not resolve the parent of a root directory.`, null, { path })
+
+        for (const part of parts) {
+            const newCurrent = (current as TDirectory).children[part] as TNode | undefined
+            if (!newCurrent) return IBFSError.eav('L2_VFS_BAD_PATH', `Entry "${part}" in "${path}" does not exist.`, null, { path })
+            current = newCurrent
+        }
+
+        return [null, current as TDirectory]
     }
 
     /**

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -25,7 +25,7 @@ export interface TDirectory {
 export interface TFile {
     /** Type of the file structure.                   */ type:      'FILE'
     /** Total size of the file's contents.            */ size:      number
-    /** Physical address of the file head block.      */ address:   Number
+    /** Physical address of the file head block.      */ address:   number
     /** The handle that's currently holding the lock. */ lock:      WeakRef<FileHandle> | null
 }
 
@@ -127,7 +127,7 @@ export default class VFS {
     public resolve(path: string): T.XEav<TNode, 'L2_VFS_BAD_PATH'> {
 
         let current: TNode = this.tree
-        const parts = VFS.normalizePath(path).split('/')
+        const parts = VFS.normalizePath(path).split('/').filter(Boolean)
 
         for (const part of parts) {
             const newCurrent = (current as TDirectory).children[part] as TNode | undefined

--- a/src/errors/IBFSError.ts
+++ b/src/errors/IBFSError.ts
@@ -243,10 +243,6 @@ const errorCodes = {
 
     // Level 2 =========================================================================================================
 
-    L2_NS_CREATE:                   'Failed to create the filesystem namespace.',
-    L2_NS_OPEN:                     'Failed to open the filesystem namespace.',
-    L2_NS_SCAN_TREE:                'Failed to scan the filesystem directory tree.',
-    
     L2_VFS_BAD_PATH:                'The resource with the requested path was not found or the path is malformed.',
     L2_VFS_NO_PERM:                 'The user does not have permission to access the requested resource.',
     L2_VFS_NO_PERM_NESTED:          `The user does not have permission to access/modify the requested resource because they don't have the permission to access one or more of its children`,
@@ -259,5 +255,13 @@ const errorCodes = {
     L2_VFS_CAN_MOVE_NODE:           'Can not move a node from the source directory to the target directory.',
     L2_VFS_CAN_DELETE_NODE:         'Can not delete a node.',
     L2_VFS_CAN_MANAGE_NODE:         'The group has no permission to manage this node.',
+
+    L2_NS_CREATE:                   'Failed to create the filesystem namespace.',
+    L2_NS_OPEN:                     'Failed to open the filesystem namespace.',
+    L2_NS_SCAN_TREE:                'Failed to scan the filesystem directory tree.',
+    
+    L2_NS_NO_PERM:                  'The user does not have permission to access the requested resource in the access mode they requested.',
+    L2_NS_OPEN_FILE:                'Failed to open a file.',
+    L2_NS_LOCKED:                   'The file/directory could not be opened because it is already in use by another consumer.',
 
 }

--- a/test/L2/namespace.test.ts
+++ b/test/L2/namespace.test.ts
@@ -1,8 +1,7 @@
 import { describe, test, expect } from "vitest"
-import IBFSError from "../../src/errors/IBFSError.js"
 import { uniform, uniformAsync, uniformSA } from "../libs/uniform.js"
-import BlockAESContext from "../../src/L0/BlockAES.js"
 import { emptyNamespace } from "../libs/empty-namespace.js"
+import BlockAESContext from "../../src/L0/BlockAES.js"
 
 describe('Namespace', () => {
 
@@ -12,13 +11,30 @@ describe('Namespace', () => {
         blockSize: 1,
         blockCount: 100,
         aesCipher: "aes-256-xts",
-        aesKey: key
+        aesKey: key,
+        rootGroup: '000000'
     })
 
-    test('ns.createEmptyNamespace', async () => {
-        const name = 'l2_empty_namespace'
-        const ns = await useEmptyNamespace(name)
-        expect(ns).not.toBeNull()
+    // test('ns.createEmptyNamespace', async () => {
+    //     const name = 'l2_empty_namespace'
+    //     const ns = await useEmptyNamespace(name)
+    //     expect(ns).not.toBeNull()
+    // })
+
+    test('ns.open', async () => {
+
+        const name = 'l2_open'
+
+        const ns        = await useEmptyNamespace(name)
+        const handle    = await uniformAsync(ns.open('/', '000000', { mode: 'r' }))
+        const rootDir   = await uniformAsync(handle.readAsDir())
+
+        expect(rootDir).toStrictEqual({
+            children: {},
+            users: { '000000': 4 },
+            meta: {}
+        })
+
     })
-    
+     
 })

--- a/test/L2/namespace.test.ts
+++ b/test/L2/namespace.test.ts
@@ -29,6 +29,8 @@ describe('Namespace', () => {
         const handle    = await uniformAsync(ns.open('/', '000000', { mode: 'r' }))
         const rootDir   = await uniformAsync(handle.readAsDir())
 
+        console.log(handle)
+
         expect(rootDir).toStrictEqual({
             children: {},
             users: { '000000': 4 },

--- a/test/L2/namespace.test.ts
+++ b/test/L2/namespace.test.ts
@@ -16,10 +16,9 @@ describe('Namespace', () => {
     })
 
     test('ns.createEmptyNamespace', async () => {
-        const name = 'test'
+        const name = 'l2_empty_namespace'
         const ns = await useEmptyNamespace(name)
         expect(ns).not.toBeNull()
-        console.log(ns)
     })
     
 })

--- a/test/L2/vfs.test.ts
+++ b/test/L2/vfs.test.ts
@@ -15,35 +15,41 @@ describe('Virtual Filesystem', () => {
                 type: 'FILE',
                 size: 1400,
                 address: 10,
+                lock: null,
             },
             'folder1': {
                 type: 'DIR',
                 size: 0,
                 address: 20,
                 perms: {},
+                lock: null,
                 children: {
                     'file2.txt': {
                         type: 'FILE',
                         size: 5000,
                         address: 30,
+                        lock: null,
                     },
                     'folder2': {
                         type: 'DIR',
                         size: 0,
                         address: 40,
                         perms: { group1: 0 },
+                        lock: null,
                         children: {
                             'file3.txt': {
                                 type: 'FILE',
                                 size: 300,
                                 address: 50,
+                                lock: null,
                             },
                             'folder3': {
                                 type: 'DIR',
                                 size: 0,
                                 address: 60,
                                 perms: { group1: 1 },
-                                children: {}
+                                children: {},
+                                lock: null,
                             }
                         },
                     },
@@ -56,9 +62,9 @@ describe('Virtual Filesystem', () => {
         expect(vfs.canReadNode('/', 'group2')!.has('L2_VFS_NO_PERM')).toBe(true)
 
         // File directly in root
-        expect(vfs.canReadNode('/file1.txt',    'group1')).toBe(undefined)
+        expect(vfs.canReadNode('/file1.txt', 'group1')).toBe(undefined)
         expect(vfs.canReadNode('/not-existent', 'group1')!.has('L2_VFS_BAD_PATH')).toBe(true)
-        expect(vfs.canReadNode('/file1.txt',    'group2')!.has('L2_VFS_NO_PERM')).toBe(true)
+        expect(vfs.canReadNode('/file1.txt', 'group2')!.has('L2_VFS_NO_PERM')).toBe(true)
 
         // Nested file
         expect(vfs.canReadNode('/folder1/file2.txt', 'group1')).toBe(undefined)
@@ -71,7 +77,7 @@ describe('Virtual Filesystem', () => {
         // Nested folder whose parent has denied permissions
         expect(vfs.canReadNode('/folder1/folder2/folder3/', 'group1')).toBeInstanceOf(IBFSError)
         expect(vfs.canReadNode('/folder1/folder2/folder3/', 'group2')!.has('L2_VFS_NO_PERM')).toBe(true)
-        
+
     })
 
     test('VFS.canWriteNode', () => {
@@ -82,17 +88,20 @@ describe('Virtual Filesystem', () => {
                 type: 'FILE',
                 size: 1400,
                 address: 10,
+                lock: null,
             },
             'folder1': {
                 type: 'DIR',
                 size: 0,
                 address: 20,
                 perms: { group1: 2, group2: 0 },
+                lock: null,
                 children: {
                     'file2.txt': {
                         type: 'FILE',
                         size: 5000,
                         address: 30,
+                        lock: null,
                     }
                 }
             }
@@ -103,9 +112,9 @@ describe('Virtual Filesystem', () => {
         expect(vfs.canWriteNode('/', 'group2')).toBe(undefined)
 
         // File directly in root
-        expect(vfs.canWriteNode('/file1.txt',    'group1')!.has('L2_VFS_NO_PERM')).toBe(true)
+        expect(vfs.canWriteNode('/file1.txt', 'group1')!.has('L2_VFS_NO_PERM')).toBe(true)
         expect(vfs.canWriteNode('/not-existent', 'group1')!.has('L2_VFS_NO_PERM')).toBe(true)
-        expect(vfs.canWriteNode('/file1.txt',    'group2')).toBe(undefined)
+        expect(vfs.canWriteNode('/file1.txt', 'group2')).toBe(undefined)
 
         // Nested file
         expect(vfs.canWriteNode('/folder1/file2.txt', 'group1')).toBe(undefined)
@@ -123,17 +132,20 @@ describe('Virtual Filesystem', () => {
                 type: 'FILE',
                 size: 1400,
                 address: 10,
+                lock: null,
             },
             'folder1': {
                 type: 'DIR',
                 size: 0,
                 address: 20,
                 perms: { group1: 3, group3: 3 },
+                lock: null,
                 children: {
                     'file2.txt': {
                         type: 'FILE',
                         size: 5000,
                         address: 30,
+                        lock: null,
                     }
                 }
             },
@@ -171,17 +183,20 @@ describe('Virtual Filesystem', () => {
                 type: 'FILE',
                 size: 1400,
                 address: 10,
+                lock: null,
             },
             'folder1': {
                 type: 'DIR',
                 size: 0,
                 address: 20,
                 perms: { group1: 3, group3: 3 },
+                lock: null,
                 children: {
                     'file2.txt': {
                         type: 'FILE',
                         size: 5000,
                         address: 30,
+                        lock: null,
                     }
                 }
             },
@@ -203,7 +218,7 @@ describe('Virtual Filesystem', () => {
 
 
     })
-    
+
     test('VFS.canRenameNode', () => {
 
         vfs.tree.perms = { group1: 1, group2: 4, group3: 0 }
@@ -212,17 +227,20 @@ describe('Virtual Filesystem', () => {
                 type: 'FILE',
                 size: 1400,
                 address: 10,
+                lock: null,
             },
             'folder1': {
                 type: 'DIR',
                 size: 0,
                 address: 20,
                 perms: { group1: 3, group3: 3 },
+                lock: null,
                 children: {
                     'file2.txt': {
                         type: 'FILE',
                         size: 5000,
                         address: 30,
+                        lock: null,
                     }
                 }
             },
@@ -241,33 +259,37 @@ describe('Virtual Filesystem', () => {
 
         // Rename to an already taken name
         expect(vfs.canRenameNode('file1.txt', 'folder1', 'group2')!.has('L2_VFS_ALREADY_EXISTS')).toBe(true)
-        
+
     })
 
     test('VFS.canMoveNode', () => {
-        
+
         vfs.tree.perms = { group1: 1, group2: 4, group3: 0 }
         vfs.tree.children = {
             'file1.txt': {
                 type: 'FILE',
                 size: 1400,
                 address: 10,
+                lock: null,
             },
             'folder1': {
                 type: 'DIR',
                 size: 0,
                 address: 20,
                 perms: { group1: 3 },
+                lock: null,
                 children: {
                     'file2.txt': {
                         type: 'FILE',
                         size: 5000,
                         address: 30,
+                        lock: null,
                     },
                     'file4.txt': {
                         type: 'FILE',
                         size: 400,
                         address: 60,
+                        lock: null,
                     }
                 }
             },
@@ -276,16 +298,19 @@ describe('Virtual Filesystem', () => {
                 size: 0,
                 address: 40,
                 perms: { group1: 1 },
+                lock: null,
                 children: {
                     'file3.txt': {
                         type: 'FILE',
                         size: 300,
                         address: 50,
+                        lock: null,
                     },
                     'file4.txt': {
                         type: 'FILE',
                         size: 400,
                         address: 60,
+                        lock: null,
                     }
                 }
             }
@@ -302,7 +327,7 @@ describe('Virtual Filesystem', () => {
         // Move item from read-only dir to a write-enabled dir
         expect(vfs.canMoveNode('/folder2/file3.txt', '/folder1', 'group1')!.has('L2_VFS_NO_PERM')).toBe(true)
         expect(vfs.canMoveNode('/folder2/file3.txt', '/folder1', 'group2')).toBe(undefined)
-        
+
         // Move item to a directory with an item of the same name
         expect(vfs.canMoveNode('/folder1/file4.txt', '/folder2', 'group2')!.has('L2_VFS_ALREADY_EXISTS')).toBe(true)
 
@@ -316,24 +341,28 @@ describe('Virtual Filesystem', () => {
                 type: 'FILE',
                 size: 1400,
                 address: 10,
+                lock: null,
             },
             'folder1': {
                 type: 'DIR',
                 size: 0,
                 address: 20,
                 perms: { group2: 2 },
+                lock: null,
                 children: {
                     'file2.txt': {
                         type: 'FILE',
                         size: 5000,
                         address: 30,
+                        lock: null,
                     },
                     'folder2': {
                         type: 'DIR',
                         size: 0,
                         address: 40,
                         perms: { group2: 1 },
-                        children: {}
+                        children: {},
+                        lock: null,
                     }
                 }
             }
@@ -360,7 +389,7 @@ describe('Virtual Filesystem', () => {
         // Delete folder with children the user doesn't have write access to
         expect(vfs.canDeleteNode('/folder1', 'group2')!.has('L2_VFS_NO_PERM_NESTED')).toBe(true)
 
-        
+
     })
-    
+
 })


### PR DESCRIPTION
Settled with a WeakRef-based reference locking mechanism for VFS nodes, where each locked node points through a WeakRef to the handle currently locking the item, making it easy to reuse active read-only handles and providing future possibility to access individual nodes outside their user's scopes.