### PR TITLE
Feat/vfs lock checks

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -2,3 +2,7 @@
 
 ## Directory name length checks
 In L2, every time a directory/file is made or renamed its name (UTF-8 string) must be checked to fit within a 16-bit range.
+
+## Limit read-only handle closures.
+Currently read-only handles being shared makes it possible for a single user to close a handle multiple times
+causing it to close for other users that share the same handle.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.18.0",
-        "typescript": "5.7.3",
+        "typescript": "^5.9.2",
         "vitest": "^3.2.4"
       },
       "engines": {
@@ -1349,9 +1349,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -790,6 +790,7 @@
       "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1166,6 +1167,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1375,6 +1377,7 @@
       "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/4S1ght/ibfs#readme",
   "devDependencies": {
     "@types/node": "^22.18.0",
-    "typescript": "5.7.3",
+    "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   }
 }

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -15,7 +15,6 @@ export const MB_8   = 8388608
 export const MB_16  = 16777216
 
 export const VOLUME_EXT_NAME = '.ibfs'
-export const ADSPACE_EXT_NAME = '.adspace'
 
 export const SPEC_MAJOR = 2
 export const SPEC_MINOR = 0

--- a/src/L1/Filesystem.ts
+++ b/src/L1/Filesystem.ts
@@ -176,7 +176,7 @@ export default class Filesystem {
                     const closeError = await fh.close()
                     if (closeError) return IBFSError.eav('L1_FS_ADSPACE_SCAN', null, closeError)
 
-                    return [null, VFS.file(address, size)]
+                    return [null, VFS.FILE(address, size)]
 
                 }
 
@@ -188,7 +188,7 @@ export default class Filesystem {
                     if (readError) return IBFSError.eav('L1_FS_ADSPACE_SCAN', null, readError)
                     if (closeError) return IBFSError.eav('L1_FS_ADSPACE_SCAN', null, closeError)
 
-                    const dirObj = VFS.dir(address, size) as TDirectory
+                    const dirObj = VFS.DIR(address, size) as TDirectory
                     dirObj.perms = dir.users
 
                     for (const filename in dir.children) {
@@ -303,10 +303,20 @@ export default class Filesystem {
      * Only `FILE` types are initialized empty.
      */
     public async createEmptyStructure(options: TCreateStructOptions): T.XEavA<number, 'L1_FS_CREATE_STRUCT'> {
+
+        let headAddress: number
+        let dataAddress: number
+
+        const abort = async (cause: Error, meta: Record<any, any>) => {
+            if (headAddress) this.adSpace.free(headAddress)
+            if (dataAddress) this.adSpace.free(dataAddress)
+            return IBFSError.eav('L1_FS_CREATE_STRUCT', null, cause, meta)
+        }
+
         try {
             
-            const headAddress = this.adSpace.alloc()
-            const dataAddress = this.adSpace.alloc()
+            headAddress = this.adSpace.alloc()
+            dataAddress = this.adSpace.alloc()
 
             const headBody = Buffer.allocUnsafe(8)
             headBody.writeBigInt64LE(BigInt(dataAddress), 0)
@@ -321,7 +331,7 @@ export default class Filesystem {
                 address: headAddress
             })
 
-            if (headError) return IBFSError.eav('L1_FS_CREATE_STRUCT', null, headError)
+            if (headError) return await abort(headError, options)
 
             const dataBody = options.type === 'FILE'
                 ? Buffer.alloc(0)
@@ -333,13 +343,13 @@ export default class Filesystem {
                 address: dataAddress
             })
 
-            if (dataError) return IBFSError.eav('L1_FS_CREATE_STRUCT', null, dataError)
+            if (dataError) return await abort(dataError, options)
 
             return [null, headAddress]
 
         } 
         catch (error) {
-            return IBFSError.eav('L1_FS_CREATE_STRUCT', null, error as Error)
+            return await abort(error as Error, options)
         }
     }
 

--- a/src/L1/caching/InstanceRegistry.ts
+++ b/src/L1/caching/InstanceRegistry.ts
@@ -1,8 +1,10 @@
+// TODO: Refactor the entire registry to use a single map for both metadata and references
+// in order to simplify its logic.
+
 // Imports =============================================================================================================
 
 import { styleText } from "node:util"
 import { toGridString } from "../../misc/toGridString.js"
-
 
 // Types ===============================================================================================================
 

--- a/src/L1/file/FileHandle.ts
+++ b/src/L1/file/FileHandle.ts
@@ -101,9 +101,6 @@ export default class FileHandle extends EventEmitter {
             // Set open flags ---------------------
             self._isOpen = true
 
-            // Cache file handle ------------------
-            // TODO: Cache the file handle
-
             return [null, self]
             
         } 
@@ -132,13 +129,7 @@ export default class FileHandle extends EventEmitter {
 
             // Fail silently if the file is already closed or is still busy.
             if (!this._isOpen) return new IBFSError('L1_FH_CLOSE', 'The handle is already closed')
-
-            // TODO: instead of failing to close when multiple streams are running (which might be the case when sharing a cached handle)
-            // proceed normally until final-close FINALIZE_HANDLE_CLOSE is called, at which point assume exclusive access and terminate
-            // underlying streams immediately.
-            
-            // Also introduce a mechanism for preventing a single user from closing a handle multiple 
-            // times causing possible race conditions and filesystem inconsistencies. 
+                
             if (this.isBusy()) return new IBFSError('L1_FH_CLOSE', `Can't close the handle because it's busy. Wait for`
                 +` all read/write activity to finish or terminate all active streams before closing.`)
 

--- a/src/L1/file/FileHandle.ts
+++ b/src/L1/file/FileHandle.ts
@@ -132,6 +132,13 @@ export default class FileHandle extends EventEmitter {
 
             // Fail silently if the file is already closed or is still busy.
             if (!this._isOpen) return new IBFSError('L1_FH_CLOSE', 'The handle is already closed')
+
+            // TODO: instead of failing to close when multiple streams are running (which might be the case when sharing a cached handle)
+            // proceed normally until final-close FINALIZE_HANDLE_CLOSE is called, at which point assume exclusive access and terminate
+            // underlying streams immediately.
+            
+            // Also introduce a mechanism for preventing a single user from closing a handle multiple 
+            // times causing possible race conditions and filesystem inconsistencies. 
             if (this.isBusy()) return new IBFSError('L1_FH_CLOSE', `Can't close the handle because it's busy. Wait for`
                 +` all read/write activity to finish or terminate all active streams before closing.`)
 
@@ -455,9 +462,9 @@ export default class FileHandle extends EventEmitter {
                 "Commit frequency": stream._fbmCommitFrequency 
             }
             this._ws.addRef('stream', stream, streamMeta)
-            stream.once('end',   () => this._ws.removeRef('stream'))
-            stream.once('close', () => this._ws.removeRef('stream'))
-            stream.once('error', () => this._ws.removeRef('stream'))
+            stream.once('finish', () => this._ws.removeRef('stream'))
+            stream.once('close',  () => this._ws.removeRef('stream'))
+            stream.once('error',  () => this._ws.removeRef('stream'))
         }
         else {
             const streamMeta = { 

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -152,6 +152,7 @@ export default class Namespace {
             // File creation ---------------------------------------------
 
             if (accessError) {
+                if (accessError.code === 'L2_VFS_LOCKED') return IBFSError.eav('L2_NS_LOCKED', null, accessError, { path, group, options })
                 if (accessError.code === 'L2_VFS_BAD_PATH' && Object.hasOwn(accessError.meta, 'missingTarget') && options.create && options.mode !== 'r') {
 
                     const cantMake = this.vfs.canMakeNode(path, group)

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -25,13 +25,18 @@ export interface TNSOpenOptions extends Omit<TFSOpenFile, 'fileAddress'> {
     /** Whether to create the file if it does not exist. */ create?: boolean
 }
 
-export interface TNSReadOptions extends BaseReadOptions {
-    /** Offset from start of the file to begin reading from. */ offset?: number
-    /** Number of bytes to read from the offset.             */ length: number
-}
+// export interface TNSReadOptions extends BaseReadOptions {
+//     /** Offset from start of the file to begin reading from. */ offset?: number
+//     /** Number of bytes to read from the offset.             */ length: number
+// }
 
 export interface TNSReadFileOptions       extends BaseReadOptions              {}
 export interface TNSOpenReadStreamOptions extends BaseReadOptions, TFRSOptions {}
+
+export interface TNSWriteFileOptions {
+    /** Whether to create the file if it does not exist. */ create?: boolean
+
+}
 
 // Exports =============================================================================================================
 
@@ -208,36 +213,36 @@ export default class Namespace {
      * @param options.integrity Whether to perform data integrity checks.
      * @returns `[error, null] | [null, Buffer]`
      */
-    public async read(path: string, group: string, options: TNSReadOptions): T.XEavA<Buffer, 'L2_NS_READ'> {
+    // public async read(path: string, group: string, options: TNSReadOptions): T.XEavA<Buffer, 'L2_NS_READ'> {
 
-        let fh: FileHandle | undefined = undefined
+    //     let fh: FileHandle | undefined = undefined
 
-        try {
+    //     try {
 
-            const [openError, handle] = await this.open(path, group, { ...options, mode: 'r' })
-            if (openError) return IBFSError.eav('L2_NS_READ', null, openError, { path, group, options })
-            fh = handle
+    //         const [openError, handle] = await this.open(path, group, { ...options, mode: 'r' })
+    //         if (openError) return IBFSError.eav('L2_NS_READ', null, openError, { path, group, options })
+    //         fh = handle
 
-            const [readError, data] = await handle.read(options.offset || 0, options.length, options.integrity)
-            if (readError) {
-                await fh.close()
-                return IBFSError.eav('L2_NS_READ', null, readError, { path, group, options })
-            }
+    //         const [readError, data] = await handle.read(options.offset || 0, options.length, options.integrity)
+    //         if (readError) {
+    //             await fh.close()
+    //             return IBFSError.eav('L2_NS_READ', null, readError, { path, group, options })
+    //         }
 
-            const closeError = await handle.close()
-            if (closeError) {
-                await fh.close()
-                return IBFSError.eav('L2_NS_READ', null, closeError, { path, group, options })
-            }
+    //         const closeError = await handle.close()
+    //         if (closeError) {
+    //             await fh.close()
+    //             return IBFSError.eav('L2_NS_READ', null, closeError, { path, group, options })
+    //         }
 
-            return [null, data]
+    //         return [null, data]
 
-        } 
-        catch (error) {
-            if (fh) await fh.close()
-            return IBFSError.eav('L2_NS_READ', null, error as Error, { path, group, options })    
-        }
-    }
+    //     } 
+    //     catch (error) {
+    //         if (fh) await fh.close()
+    //         return IBFSError.eav('L2_NS_READ', null, error as Error, { path, group, options })    
+    //     }
+    // }
 
     /**
      * Reads the entire contents of a file.  
@@ -321,6 +326,47 @@ export default class Namespace {
         }
     }
 
+    /**
+     * Writes the entirety of the `data` buffer to the file on the specified `path`.  
+     * This overwrites the entire file. For partial writes, use the `FileHandle` interface.
+     * @param path Path to the resource in the filesystem.
+     * @param group Group that is requesting access to the resource - used to check access permissions.
+     * @param data Data to write.
+     * @param options Write options
+     * @param options.create Whether to create the file if it does not exist. `default: true`
+     * @returns `error | undefined`
+     */
+    public async writeFile(path: string, group: string, data: Buffer, options?: TNSWriteFileOptions): T.XEavSA<'L2_NS_WRITE'> {
+
+        let fh: FileHandle | undefined = undefined
+
+        const abort = async (cause: Error) => {
+            await fh?.close()
+            return new IBFSError('L2_NS_WRITE', null, cause, { path, group, options })
+        }
+
+        try {
+
+            const opt = {
+                create: true,
+                ...options
+            }
+
+            const [openError, handle] = await this.open(path, group, { ...opt, mode: 'w' })
+            if (openError) return await abort(openError)
+            fh = handle
+
+            const writeError = await handle.writeFile(data)
+            if (writeError) return await abort(writeError)
+
+            const closeError = await handle.close()
+            if (closeError) return await abort(closeError)
+            
+        } 
+        catch (error) {
+            return await abort(error as Error)
+        }
+    }
 
     // Private helpers -------------------------------------------------------------------------------------------------
 

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -20,7 +20,9 @@ interface BaseReadOptions {
     /** Whether to perform data integrity checks during reads. */ integrity?: boolean
 }
 
-export interface TNSOpenOptions extends Omit<TFSOpenFile, 'fileAddress'> {}
+export interface TNSOpenOptions extends Omit<TFSOpenFile, 'fileAddress'> {
+    /** Whether to create the file if it does not exist. */ create?: boolean
+}
 
 export interface TNSReadOptions extends BaseReadOptions {
     /** Offset from start of the file to begin reading from. */ offset?: number
@@ -147,12 +149,22 @@ export default class Namespace {
         })
     }
 
+    /**
+     * Opens the file on a specific `path` file and returns its handle. If the file is being used by another user that
+     * conflicts with the action of opening a new handle, the call will fail and return an error. The same file can be
+     * open multiple times by different users in read-only mode, but only by a single user in write mode which requires
+     * absolute exclusive access.
+     * @param path Path to the resource in the filesystem.
+     * @param group The group that is requesting access to the resource - used to check access permissions.
+     * @param options Open options - Append, truncate, etc.
+     * @param options.mode The mode in which the file is being opened.
+     * @param options.append Whether the file should be opened in append mode - Will force every write to the end of the file.
+     * @param options.truncate Whether the file should be truncated to 0 bytes before opening it.
+     * @param options.integrity Whether to perform data integrity checks.
+     * @returns `[error, null] | [null, handle]`
+     */
     public async open(path: string, group: string, options: TNSOpenOptions): T.XEavA<FileHandle, 'L2_NS_OPEN_FILE' | 'L2_NS_NO_PERM' | 'L2_NS_LOCKED'> {
         try {
-
-            // TODO: Instead of returning a direct file handle, return a proxy that limits the number of times 
-            // "close" can be called to a single successful call to prevent a single user from closing a 
-            // read-only handle for another.
 
             const permCheckError = options.mode === 'r'
                 ? this.vfs.canReadNode(path, group)
@@ -160,8 +172,30 @@ export default class Namespace {
 
             if (permCheckError) return IBFSError.eav('L2_NS_OPEN_FILE', null, permCheckError, { path, group, options })
 
+            // File creation --------------------------------------------------
+
             const [resolveError, vfsNode] = this.vfs.resolve(path)
+
+            if (resolveError) {
+                if (options.create && resolveError.meta.missingDirect) {
+                    
+                    // TODO:
+                    // 1. Namespace.open parent directory
+                    // 2. Create empty file structure
+                    // 3. Add it to the directory table and save the directory onto the disk.
+
+                    return IBFSError.eav('L2_NS_OPEN_FILE', 'options.create not yet implemented', resolveError, { path, group, options })
+
+                }
+                else {
+                    return IBFSError.eav('L2_NS_OPEN_FILE', null, resolveError, { path, group, options })
+                }
+            }
+
+
             if (resolveError) return IBFSError.eav('L2_NS_OPEN_FILE', null, resolveError, { path, group, options })
+
+            // ----------------------------------------------------------------
 
             const handle = vfsNode.lock && vfsNode.lock.deref()
 
@@ -202,6 +236,17 @@ export default class Namespace {
         }
     }
 
+    /**
+     * Reads data from a specific place inside a file based on the `offset` and `length` parameters.  
+     * **Access limitations & locking apply. See `Namespace.open()` method.**
+     * @param path Path to the resource in the filesystem.
+     * @param group The group that is requesting access to the resource - used to check access permissions.
+     * @param options Open options.
+     * @param options.offset The offset from the start of the file.
+     * @param options.length The number of bytes to read.
+     * @param options.integrity Whether to perform data integrity checks.
+     * @returns `[error, null] | [null, Buffer]`
+     */
     public async read(path: string, group: string, options: TNSReadOptions): T.XEavA<Buffer, 'L2_NS_READ'> {
 
         let fh: FileHandle | undefined = undefined
@@ -233,6 +278,15 @@ export default class Namespace {
         }
     }
 
+    /**
+     * Reads the entire contents of a file.  
+     * **Access limitations & locking apply. See `Namespace.open()` method.**
+     * @param path Path to the resource in the filesystem.
+     * @param group The group that is requesting access to the resource - used to check access permissions.
+     * @param options Open options.
+     * @param options.integrity Whether to perform data integrity checks.
+     * @returns `[error, null] | [null, Buffer]`
+     */
     public async readFile(path: string, group: string, options?: TNSReadFileOptions): T.XEavA<Buffer, 'L2_NS_READ_FILE'> {
 
         let fh: FileHandle | undefined = undefined
@@ -266,6 +320,19 @@ export default class Namespace {
         }
     }
 
+    /**
+     * Opens a file and returns a read stream.  
+     * **Access limitations & locking apply. See `Namespace.open()` method.**
+     * @param path Path to the resource in the filesystem.
+     * @param group The group that is requesting access to the resource - used to check access permissions.
+     * @param options Open options.
+     * @param options.offset The offset from the start of the file to start reading from.
+     * @param options.length The number of bytes to read.
+     * @param options.maxChunkSize The maximum size of individual data chunks pushed to the stream.
+     * @param options.highWaterMark The watermark below which the stream will read more data.
+     * @param options.integrity Whether to perform data integrity checks.
+     * @returns `[error, null] | [null, FileReadStream]`
+     */
     public async createReadStream(path: string, group: string, options?: TNSOpenReadStreamOptions): T.XEavA<FileReadStream, 'L2_NS_OPEN_READ_STREAM'> {
 
         let fh: FileHandle | undefined = undefined
@@ -292,7 +359,6 @@ export default class Namespace {
             return IBFSError.eav('L2_NS_OPEN_READ_STREAM', null, error as Error, { path, group, options })
         }
     }
-
 
 
 }

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -27,10 +27,8 @@ export interface TNSReadOptions extends BaseReadOptions {
     /** Number of bytes to read from the offset.             */ length: number
 }
 
-export interface TNSReadFileOptions extends BaseReadOptions {}
-
-export interface TNSOpenReadStreamOptions extends BaseReadOptions, TFRSOptions {
-}
+export interface TNSReadFileOptions       extends BaseReadOptions              {}
+export interface TNSOpenReadStreamOptions extends BaseReadOptions, TFRSOptions {}
 
 // Exports =============================================================================================================
 
@@ -106,6 +104,49 @@ export default class Namespace {
 
     // IO methods ------------------------------------------------------------------------------------------------------
 
+    /**
+     * Wraps a file handle inside a proxy to provide limiting mechanisms on how many times certain methods
+     * are allowed to be called by individual users. This is required because read-only handles are shared
+     * across multiple users and without limiting, a single user could close the handle multiple times
+     * causing it to close for other users that share it.
+     */
+    private createHandleProxy(handle: FileHandle): FileHandle {
+
+        let closed = false
+        let closing = false
+
+        return new Proxy(handle, {
+
+            get(target, prop, receiver) {
+
+                if (closed) return new IBFSError('L2_FH_CLOSED', "The proxy to this handle has already been closed and can not be used.")
+
+                if (prop === 'close') return async () => {
+
+                    if (closing) return new IBFSError('L2_FH_CLOSING', "The proxy to this handle has already been closed and can not be used.")
+                    if (closed) return new IBFSError('L2_FH_CLOSED', "The proxy to this handle has already been closed and can not be used.")
+                    
+                    closing = true
+
+                    const closeError = target.close()
+                    if (closeError) return closeError
+
+                    closed = true
+                    closing = false
+
+                }
+                
+                const value = Reflect.get(target, prop, receiver)
+
+                return typeof value === 'function'
+                    ? value.bind(target)
+                    : value
+                    
+            }
+
+        })
+    }
+
     public async open(path: string, group: string, options: TNSOpenOptions): T.XEavA<FileHandle, 'L2_NS_OPEN_FILE' | 'L2_NS_NO_PERM' | 'L2_NS_LOCKED'> {
         try {
 
@@ -124,6 +165,7 @@ export default class Namespace {
 
             const handle = vfsNode.lock && vfsNode.lock.deref()
 
+            // No existing handle, resource is free, open straight away and lock it.
             if (!handle) {
 
                 const [openError, handle] = await this.fs.open({ fileAddress: vfsNode.address, ...options })
@@ -132,13 +174,26 @@ export default class Namespace {
                 vfsNode.lock = new WeakRef(handle)
                 handle.on('close', () => vfsNode.lock = null)
 
-                return [null, handle]
+                const proxy = this.createHandleProxy(handle)
+                return [null, proxy]
 
             }
-
+            // The resource is locked by another user.
             else {
-                if (options.mode === 'r' && handle.mode === 'r') return [null, handle]
+
+                // Reuse/share a read-only handle (done internally)
+                if (options.mode === 'r' && handle.mode === 'r') {
+
+                    const [openError, handle] = await this.fs.open({ fileAddress: vfsNode.address, ...options })
+                    if (openError) return IBFSError.eav('L2_NS_OPEN_FILE', null, openError, { path, group, options })
+
+                    const proxy = this.createHandleProxy(handle)
+                    return [null, proxy]
+
+                }
+
                 else return IBFSError.eav('L2_NS_LOCKED', null, null, { path, group, options })
+
             }
             
         } 

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -1,14 +1,17 @@
 // Imports =============================================================================================================
 
 import type * as T from '../../types.js'
-import IBFSError from '../errors/IBFSError.js'
-import FileHandle from '../L1/file/FileHandle.js'
-import FileReadStream, { TFRSOptions } from '../L1/file/FileReadStream.js'
-import FileWriteStream, { TFWSOptions } from '../L1/file/FileWriteStream.js'
-import Filesystem, { TFSInit, TFSOpenFile } from '../L1/Filesystem.js'
-import ssc from '../misc/safeShallowCopy.js'
-import VFS, { TDirectory, TNode } from './VirtualFilesystem.js'
-import np from 'node:path'
+
+import IBFSError                                from '../errors/IBFSError.js'
+import FileHandle                               from '../L1/file/FileHandle.js'
+import FileReadStream, { TFRSOptions }          from '../L1/file/FileReadStream.js'
+import FileWriteStream, { TFWSOptions }         from '../L1/file/FileWriteStream.js'
+import Filesystem, { TFSInit, TFSOpenFile }     from '../L1/Filesystem.js'
+
+import ssc                                      from '../misc/safeShallowCopy.js'
+import VFS, { TDirectory, TNode }               from './VirtualFilesystem.js'
+
+import np                                       from 'node:path'
 
 // Types ===============================================================================================================
 

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -150,6 +150,9 @@ export default class Namespace {
 
             if (accessError) {
                 if (accessError.code === 'L2_VFS_BAD_PATH' && accessError.meta.missingTarget && options.create && options.mode !== 'r') {
+
+                    const cantMake = this.vfs.canMakeNode(path, group)
+                    if (cantMake) return IBFSError.eav('L2_NS_OPEN_FILE', null, cantMake, { path, group, options })
                     
                     const [createError, fileHandle] = await this.createEmptyNode(path, group, 'FILE')
                     if (createError) return IBFSError.eav('L2_NS_OPEN_FILE', null, createError, { path, group, options })
@@ -348,7 +351,7 @@ export default class Namespace {
      * @param group Group that is requesting access to the resource - used to check access permissions.
      * @param data Data to write.
      * @param options Write options
-     * @param options.create Whether to create the file if it does not exist. `default: true`
+     * @param options.create Whether to create the file if it does not exist. @default true
      * @returns `error | undefined`
      */
     public async writeFile(path: string, group: string, data: Buffer, options?: TNSWriteFileOptions): T.XEavSA<'L2_NS_WRITE_FILE'> {
@@ -426,6 +429,60 @@ export default class Namespace {
         catch (error) {
             if (fh) await fh.close()
             return IBFSError.eav('L2_NS_OPEN_WRITE_STREAM', null, error as Error, { path, group, options })
+        }
+    }
+
+
+    public async rename(path: string, newName: string, group: string): T.XEavSA<'L2_NS_RENAME'> {
+
+        const dirname = np.dirname(path)
+        const basename = np.basename(path)
+
+        let fh: FileHandle | undefined = undefined
+        let pd: TDirectory
+
+        const abort = async (cause: Error) => {
+            // close handle
+            if (fh) await fh.close()
+            // Revert VFS changes
+            if (pd && pd.children[newName]) {
+                pd.children[basename] = pd.children[newName]
+                delete pd.children[newName]
+            }
+            return new IBFSError('L2_NS_RENAME', null, cause, { path, newName, group })
+        }
+
+        try {
+
+            const cantRename = this.vfs.canRenameNode(path, newName, group)
+            if (cantRename) return await abort(cantRename);
+
+            const [resolveError, parentDir] = this.vfs.resolveParent(path)
+            if (resolveError) return await abort(resolveError)
+            pd = parentDir
+
+            const [openError, parentHandle] = await this.open(dirname, group, { mode: 'rw' })
+            if (openError) return await abort(openError)
+            fh = parentHandle
+
+            const [readError, dirData] = await parentHandle.readAsDir()
+            if (readError) return await abort(readError)
+
+            dirData.children[newName] = dirData.children[basename]!
+            delete dirData.children[basename]
+
+            const writeError = await parentHandle.writeAsDir(dirData)
+            if (writeError) return await abort(writeError)
+
+            parentDir.children[newName] = parentDir.children[basename]!
+            delete parentDir.children[basename]
+
+            const closeError = await parentHandle.close()
+            if (closeError) return await abort(closeError)
+            
+        } 
+        catch (error) {
+            return new IBFSError('L2_NS_RENAME', null, error as Error, { path, newName, group })
         }
     }
 
@@ -540,6 +597,7 @@ export default class Namespace {
         }
     }
 
+    // TODO: Add error event handling
     private onStreamEnd(stream: FileReadStream | FileWriteStream, callback: () => void) {
         stream.on('end', callback)
         stream.on('close', callback)

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -4,6 +4,7 @@ import type * as T from '../../types.js'
 import IBFSError from '../errors/IBFSError.js'
 import FileHandle from '../L1/file/FileHandle.js'
 import FileReadStream, { TFRSOptions } from '../L1/file/FileReadStream.js'
+import FileWriteStream, { TFWSOptions } from '../L1/file/FileWriteStream.js'
 import Filesystem, { TFSInit, TFSOpenFile } from '../L1/Filesystem.js'
 import ssc from '../misc/safeShallowCopy.js'
 import VFS, { TDirectory, TNode } from './VirtualFilesystem.js'
@@ -34,8 +35,19 @@ export interface TNSReadFileOptions       extends BaseReadOptions              {
 export interface TNSOpenReadStreamOptions extends BaseReadOptions, TFRSOptions {}
 
 export interface TNSWriteFileOptions {
-    /** Whether to create the file if it does not exist. */ create?: boolean
+    /** 
+     * Whether to create the file if it does not exist.
+     * @default true
+     */ 
+    create?: boolean
+}
 
+export interface TNSOpenWriteStreamOptions extends TFWSOptions, Pick<TFSOpenFile, 'append' | 'truncate'> {
+    /** 
+     * Whether to create the file if it does not exist.
+     * @default true
+     */ 
+    create?: boolean
 }
 
 // Exports =============================================================================================================
@@ -204,7 +216,7 @@ export default class Namespace {
 
     /**
      * Reads data from a specific place inside a file based on the `offset` and `length` parameters.  
-     * **Access limitations & locking apply. See `Namespace.open()` method.**
+     * **NOTE: Access limitations & locking apply. See `Namespace.open()` method.**
      * @param path Path to the resource in the filesystem.
      * @param group The group that is requesting access to the resource - used to check access permissions.
      * @param options Open options.
@@ -246,7 +258,7 @@ export default class Namespace {
 
     /**
      * Reads the entire contents of a file.  
-     * **Access limitations & locking apply. See `Namespace.open()` method.**
+     * **NOTE: Access limitations & locking apply. See `Namespace.open()` method.**
      * @param path Path to the resource in the filesystem.
      * @param group The group that is requesting access to the resource - used to check access permissions.
      * @param options Open options.
@@ -288,7 +300,7 @@ export default class Namespace {
 
     /**
      * Opens a file and returns a read stream.  
-     * **Access limitations & locking apply. See `Namespace.open()` method.**
+     * **NOTE: Access limitations & locking apply. See `Namespace.open()` method.**
      * @param path Path to the resource in the filesystem.
      * @param group The group that is requesting access to the resource - used to check access permissions.
      * @param options Open options.
@@ -316,6 +328,8 @@ export default class Namespace {
                 return IBFSError.eav('L2_NS_OPEN_READ_STREAM', null, streamError, { path, group, options })
             }
 
+            this.onStreamEnd(stream, () => fh?.close())
+
             return [null, stream]
 
             
@@ -328,7 +342,8 @@ export default class Namespace {
 
     /**
      * Writes the entirety of the `data` buffer to the file on the specified `path`.  
-     * This overwrites the entire file. For partial writes, use the `FileHandle` interface.
+     * This overwrites the entire file. For partial writes, use the `FileHandle` interface.  
+     * **NOTE: Access limitations & locking apply. See `Namespace.open()` method.**
      * @param path Path to the resource in the filesystem.
      * @param group Group that is requesting access to the resource - used to check access permissions.
      * @param data Data to write.
@@ -336,13 +351,13 @@ export default class Namespace {
      * @param options.create Whether to create the file if it does not exist. `default: true`
      * @returns `error | undefined`
      */
-    public async writeFile(path: string, group: string, data: Buffer, options?: TNSWriteFileOptions): T.XEavSA<'L2_NS_WRITE'> {
+    public async writeFile(path: string, group: string, data: Buffer, options?: TNSWriteFileOptions): T.XEavSA<'L2_NS_WRITE_FILE'> {
 
         let fh: FileHandle | undefined = undefined
 
         const abort = async (cause: Error) => {
             await fh?.close()
-            return new IBFSError('L2_NS_WRITE', null, cause, { path, group, options })
+            return new IBFSError('L2_NS_WRITE_FILE', null, cause, { path, group, options })
         }
 
         try {
@@ -365,6 +380,52 @@ export default class Namespace {
         } 
         catch (error) {
             return await abort(error as Error)
+        }
+    }
+
+    /**
+     * Opens a file and returns a write stream.  
+     * **NOTE: Access limitations & locking apply. See `Namespace.open()` method.**
+     * @param path Path to the resource in the filesystem.
+     * @param group The group that is requesting access to the resource - used to check access permissions.
+     * @param options Open options.
+     * @param options.offset The offset from the start of the file to start writing to. @default 0 // - "append" option takes precedence if set.
+     * @param options.highWaterMark The watermark below which the stream will write more data. @default 65536 // 64kB
+     * @param options.append Whether to append all writes to the end of the file. @default false
+     * @param options.create Whether to create the file if it does not exist. @default true
+     * @param options.truncate Whether to truncate the file if it already exists. @default false
+     * @returns `[error, null] | [null, FileWriteStream]`
+     */
+    public async createWriteStream(path: string, group: string, options?: TNSOpenWriteStreamOptions): T.XEavA<FileWriteStream, 'L2_NS_OPEN_WRITE_STREAM'> {
+        
+        let fh: FileHandle | undefined = undefined
+        
+        try {
+
+            const opt = {
+                create: true,
+                ...options
+            }
+
+            const [openError, handle] = await this.open(path, group, { ...opt, mode: 'w' })
+            if (openError) return IBFSError.eav('L2_NS_OPEN_WRITE_STREAM', null, openError, { path, group, options })
+            fh = handle
+
+            const [streamError, stream] = await handle.createWriteStream(opt)
+
+            if (streamError) {
+                await fh.close()
+                return IBFSError.eav('L2_NS_OPEN_WRITE_STREAM', null, streamError, { path, group, options })
+            }
+
+            this.onStreamEnd(stream, () => fh?.close())
+
+            return [null, stream]
+            
+        } 
+        catch (error) {
+            if (fh) await fh.close()
+            return IBFSError.eav('L2_NS_OPEN_WRITE_STREAM', null, error as Error, { path, group, options })
         }
     }
 
@@ -433,21 +494,21 @@ export default class Namespace {
 
         const abort = async (cause: Error, meta: Record<any, any>) => {
             await parentDir?.close()
-            if (parentNode.children[basename]) parentNode.children[basename]!.lock = null
+            if (parentNode && parentNode.children[basename]) parentNode.children[basename]!.lock = null
             return IBFSError.eav('L2_NS_CREATE_NODE', null, cause, meta)
         }
 
         try {
 
             const cantCreate = this.vfs.canMakeNode(path, group)    
-            if (cantCreate) return IBFSError.eav('L2_NS_CREATE_NODE', null, cantCreate, { path, group })
+            if (cantCreate) return abort(cantCreate, { path, group })
 
             const [resError, $parentNode] = this.vfs.resolveParent(path)
-            if (resError) return IBFSError.eav('L2_NS_CREATE_NODE', null, resError, { path, group })
+            if (resError) return await abort(resError, { path, group })
             parentNode = $parentNode
             
             const [parentError, $parentDir] = await this.open(dirname, group, { mode: 'rw' })
-            if (parentError) return IBFSError.eav('L2_NS_CREATE_NODE', null, parentError, { path, group })
+            if (parentError) return abort(parentError, { path, group })
             parentDir = $parentDir
 
             const [childError, childAddress] = await this.fs.createEmptyStructure({ type })
@@ -477,6 +538,12 @@ export default class Namespace {
         catch (error) {
             return IBFSError.eav('L2_NS_CREATE_NODE', null, error as Error, { path, group })    
         }
+    }
+
+    private onStreamEnd(stream: FileReadStream | FileWriteStream, callback: () => void) {
+        stream.on('end', callback)
+        stream.on('close', callback)
+        stream.on('finish', callback)
     }
 
 }

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -3,6 +3,7 @@
 import type * as T from '../../types.js'
 import IBFSError from '../errors/IBFSError.js'
 import FileHandle from '../L1/file/FileHandle.js'
+import FileReadStream, { TFRSOptions } from '../L1/file/FileReadStream.js'
 import Filesystem, { TFSInit, TFSOpenFile } from '../L1/Filesystem.js'
 import ssc from '../misc/safeShallowCopy.js'
 import VFS, { TDirectory } from './VirtualFilesystem.js'
@@ -19,16 +20,16 @@ interface BaseReadOptions {
     /** Whether to perform data integrity checks during reads. */ integrity?: boolean
 }
 
+export interface TNSOpenOptions extends Omit<TFSOpenFile, 'fileAddress'> {}
+
 export interface TNSReadOptions extends BaseReadOptions {
-    /** Offset from start of the file to begin reading from. */ offset: number
+    /** Offset from start of the file to begin reading from. */ offset?: number
     /** Number of bytes to read from the offset.             */ length: number
 }
 
 export interface TNSReadFileOptions extends BaseReadOptions {}
 
-export interface TNSOpenReadStreamOptions extends BaseReadOptions {
-    /** Offset from start of the file to begin reading from. */ offset: number
-    /** Number of bytes to read from the offset.             */ length: number
+export interface TNSOpenReadStreamOptions extends BaseReadOptions, TFRSOptions {
 }
 
 // Exports =============================================================================================================
@@ -105,14 +106,18 @@ export default class Namespace {
 
     // IO methods ------------------------------------------------------------------------------------------------------
 
-    public async open(path: string, group: string, options: Omit<TFSOpenFile, 'fileAddress'>): T.XEavA<FileHandle, 'L2_NS_OPEN_FILE' | 'L2_NS_NO_PERM' | 'L2_NS_LOCKED'> {
+    public async open(path: string, group: string, options: TNSOpenOptions): T.XEavA<FileHandle, 'L2_NS_OPEN_FILE' | 'L2_NS_NO_PERM' | 'L2_NS_LOCKED'> {
         try {
 
-            const isDisallowed = options.mode === 'r'
+            // TODO: Instead of returning a direct file handle, return a proxy that limits the number of times 
+            // "close" can be called to a single successful call to prevent a single user from closing a 
+            // read-only handle for another.
+
+            const permCheckError = options.mode === 'r'
                 ? this.vfs.canReadNode(path, group)
                 : this.vfs.canWriteNode(path, group)
 
-            if (isDisallowed) return IBFSError.eav('L2_NS_OPEN_FILE', null, isDisallowed, { path, group, options })
+            if (permCheckError) return IBFSError.eav('L2_NS_OPEN_FILE', null, permCheckError, { path, group, options })
 
             const [resolveError, vfsNode] = this.vfs.resolve(path)
             if (resolveError) return IBFSError.eav('L2_NS_OPEN_FILE', null, resolveError, { path, group, options })
@@ -142,11 +147,96 @@ export default class Namespace {
         }
     }
 
-    public async read(path: string, group: string, options: TNSReadOptions) {}
+    public async read(path: string, group: string, options: TNSReadOptions): T.XEavA<Buffer, 'L2_NS_READ'> {
 
-    public async readFile(path: string, group: string, options?: TNSReadFileOptions) {}
+        let fh: FileHandle | undefined = undefined
 
-    public async openReadStream(path: string, group: string, options?: TNSOpenReadStreamOptions) {}
+        try {
+
+            const [openError, handle] = await this.open(path, group, { ...options, mode: 'r' })
+            if (openError) return IBFSError.eav('L2_NS_READ', null, openError, { path, group, options })
+            fh = handle
+
+            const [readError, data] = await handle.read(options.offset || 0, options.length, options.integrity)
+            if (readError) {
+                await fh.close()
+                return IBFSError.eav('L2_NS_READ', null, readError, { path, group, options })
+            }
+
+            const closeError = await handle.close()
+            if (closeError) {
+                await fh.close()
+                return IBFSError.eav('L2_NS_READ', null, closeError, { path, group, options })
+            }
+
+            return [null, data]
+
+        } 
+        catch (error) {
+            if (fh) await fh.close()
+            return IBFSError.eav('L2_NS_READ', null, error as Error, { path, group, options })    
+        }
+    }
+
+    public async readFile(path: string, group: string, options?: TNSReadFileOptions): T.XEavA<Buffer, 'L2_NS_READ_FILE'> {
+
+        let fh: FileHandle | undefined = undefined
+
+        try {
+
+            const opt = options || {} 
+            
+            const [openError, handle] = await this.open(path, group, { ...options, mode: 'r' })
+            if (openError) return IBFSError.eav('L2_NS_READ_FILE', null, openError, { path, group, options })
+            fh = handle
+
+            const [readError, data] = await handle.readFile(opt.integrity)
+            if (readError) {
+                await fh.close()
+                return IBFSError.eav('L2_NS_READ_FILE', null, readError, { path, group, options })
+            }
+
+            const closeError = await handle.close()
+            if (closeError) {
+                await fh.close()
+                return IBFSError.eav('L2_NS_READ_FILE', null, closeError, { path, group, options })
+            }
+
+            return [null, data]
+
+        } 
+        catch (error) {
+            if (fh) await fh.close()
+            return IBFSError.eav('L2_NS_READ_FILE', null, error as Error, { path, group, options })
+        }
+    }
+
+    public async createReadStream(path: string, group: string, options?: TNSOpenReadStreamOptions): T.XEavA<FileReadStream, 'L2_NS_OPEN_READ_STREAM'> {
+
+        let fh: FileHandle | undefined = undefined
+
+        try {
+
+            const [openError, handle] = await this.open(path, group, { ...options, mode: 'r' })
+            if (openError) return IBFSError.eav('L2_NS_OPEN_READ_STREAM', null, openError, { path, group, options })
+            fh = handle
+
+            const [streamError, stream] = await handle.createReadStream(options)
+
+            if (streamError) {
+                await fh.close()
+                return IBFSError.eav('L2_NS_OPEN_READ_STREAM', null, streamError, { path, group, options })
+            }
+
+            return [null, stream]
+
+            
+        } 
+        catch (error) {
+            if (fh) await fh.close()
+            return IBFSError.eav('L2_NS_OPEN_READ_STREAM', null, error as Error, { path, group, options })
+        }
+    }
 
 
 

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -6,7 +6,8 @@ import FileHandle from '../L1/file/FileHandle.js'
 import FileReadStream, { TFRSOptions } from '../L1/file/FileReadStream.js'
 import Filesystem, { TFSInit, TFSOpenFile } from '../L1/Filesystem.js'
 import ssc from '../misc/safeShallowCopy.js'
-import VFS, { TDirectory } from './VirtualFilesystem.js'
+import VFS, { TDirectory, TNode } from './VirtualFilesystem.js'
+import np from 'node:path'
 
 // Types ===============================================================================================================
 
@@ -107,49 +108,6 @@ export default class Namespace {
     // IO methods ------------------------------------------------------------------------------------------------------
 
     /**
-     * Wraps a file handle inside a proxy to provide limiting mechanisms on how many times certain methods
-     * are allowed to be called by individual users. This is required because read-only handles are shared
-     * across multiple users and without limiting, a single user could close the handle multiple times
-     * causing it to close for other users that share it.
-     */
-    private createHandleProxy(handle: FileHandle): FileHandle {
-
-        let closed = false
-        let closing = false
-
-        return new Proxy(handle, {
-
-            get(target, prop, receiver) {
-
-                if (closed) return new IBFSError('L2_FH_CLOSED', "The proxy to this handle has already been closed and can not be used.")
-
-                if (prop === 'close') return async () => {
-
-                    if (closing) return new IBFSError('L2_FH_CLOSING', "The proxy to this handle has already been closed and can not be used.")
-                    if (closed) return new IBFSError('L2_FH_CLOSED', "The proxy to this handle has already been closed and can not be used.")
-                    
-                    closing = true
-
-                    const closeError = target.close()
-                    if (closeError) return closeError
-
-                    closed = true
-                    closing = false
-
-                }
-                
-                const value = Reflect.get(target, prop, receiver)
-
-                return typeof value === 'function'
-                    ? value.bind(target)
-                    : value
-                    
-            }
-
-        })
-    }
-
-    /**
      * Opens the file on a specific `path` file and returns its handle. If the file is being used by another user that
      * conflicts with the action of opening a new handle, the call will fail and return an error. The same file can be
      * open multiple times by different users in read-only mode, but only by a single user in write mode which requires
@@ -159,6 +117,7 @@ export default class Namespace {
      * @param options Open options - Append, truncate, etc.
      * @param options.mode The mode in which the file is being opened.
      * @param options.append Whether the file should be opened in append mode - Will force every write to the end of the file.
+     * @param options.create Whether the file should be created if it does not exist.
      * @param options.truncate Whether the file should be truncated to 0 bytes before opening it.
      * @param options.integrity Whether to perform data integrity checks.
      * @returns `[error, null] | [null, handle]`
@@ -166,38 +125,40 @@ export default class Namespace {
     public async open(path: string, group: string, options: TNSOpenOptions): T.XEavA<FileHandle, 'L2_NS_OPEN_FILE' | 'L2_NS_NO_PERM' | 'L2_NS_LOCKED'> {
         try {
 
-            const permCheckError = options.mode === 'r'
+            const accessError = options.mode === 'r'
                 ? this.vfs.canReadNode(path, group)
                 : this.vfs.canWriteNode(path, group)
 
-            if (permCheckError) return IBFSError.eav('L2_NS_OPEN_FILE', null, permCheckError, { path, group, options })
+            // File creation ---------------------------------------------
 
-            // File creation --------------------------------------------------
-
-            const [resolveError, vfsNode] = this.vfs.resolve(path)
-
-            if (resolveError) {
-                if (options.create && resolveError.meta.missingDirect) {
+            if (accessError) {
+                if (accessError.code === 'L2_VFS_BAD_PATH' && accessError.meta.missingTarget && options.create && options.mode !== 'r') {
                     
-                    // TODO:
-                    // 1. Namespace.open parent directory
-                    // 2. Create empty file structure
-                    // 3. Add it to the directory table and save the directory onto the disk.
+                    const [createError, fileHandle] = await this.createEmptyNode(path, group, 'FILE')
+                    if (createError) return IBFSError.eav('L2_NS_OPEN_FILE', null, createError, { path, group, options })
+                    
+                    const [resolveError, fileNode] = this.vfs.resolve(path)
+                    if (resolveError) {
+                        await fileHandle.close()
+                        return IBFSError.eav('L2_NS_OPEN_FILE', null, resolveError, { path, group, options })
+                    }
 
-                    return IBFSError.eav('L2_NS_OPEN_FILE', 'options.create not yet implemented', resolveError, { path, group, options })
+                    fileNode.lock = new WeakRef(fileHandle)
+                    fileHandle.on('close', () => fileNode.lock = null)
+
+                    const proxy = this.createHandleProxy(fileHandle)
+                    return [null, proxy]
 
                 }
-                else {
-                    return IBFSError.eav('L2_NS_OPEN_FILE', null, resolveError, { path, group, options })
-                }
+                else return IBFSError.eav('L2_NS_OPEN_FILE', null, accessError, { path, group, options })
             }
 
+            // -----------------------------------------------------------
 
+            const [resolveError, vfsNode] = this.vfs.resolve(path)
             if (resolveError) return IBFSError.eav('L2_NS_OPEN_FILE', null, resolveError, { path, group, options })
 
-            // ----------------------------------------------------------------
-
-            const handle = vfsNode.lock && vfsNode.lock.deref()
+            const handle = vfsNode.lock && vfsNode.lock !== 'pending' && vfsNode.lock.deref()
 
             // No existing handle, resource is free, open straight away and lock it.
             if (!handle) {
@@ -215,7 +176,7 @@ export default class Namespace {
             // The resource is locked by another user.
             else {
 
-                // Reuse/share a read-only handle (done internally)
+                // Reuse/share a read-only handle if one exists (done internally)
                 if (options.mode === 'r' && handle.mode === 'r') {
 
                     const [openError, handle] = await this.fs.open({ fileAddress: vfsNode.address, ...options })
@@ -225,7 +186,7 @@ export default class Namespace {
                     return [null, proxy]
 
                 }
-
+                // Return an error if the file is locked by another user in write mode.
                 else return IBFSError.eav('L2_NS_LOCKED', null, null, { path, group, options })
 
             }
@@ -360,5 +321,116 @@ export default class Namespace {
         }
     }
 
+
+    // Private helpers -------------------------------------------------------------------------------------------------
+
+    /**
+     * Wraps a file handle inside a proxy to provide limiting mechanisms on how many times certain methods
+     * are allowed to be called by individual users. This is required because read-only handles are shared
+     * across multiple users and without limiting, a single user could close the handle multiple times
+     * causing it to close for other users that share it.
+     * 
+     * This function will likely evolve as new functionality is added to shared read-only handles.
+     */
+    private createHandleProxy(handle: FileHandle): FileHandle {
+
+        let closed = false
+        let closing = false
+
+        return new Proxy(handle, {
+
+            get(target, prop, receiver) {
+
+                if (closed) return new IBFSError('L2_FH_CLOSED', "The proxy to this handle has already been closed and can not be used.")
+
+                if (prop === 'close') return async () => {
+
+                    if (closing) return new IBFSError('L2_FH_CLOSING', "The proxy to this handle has already been closed and can not be used.")
+                    if (closed) return new IBFSError('L2_FH_CLOSED', "The proxy to this handle has already been closed and can not be used.")
+                    
+                    closing = true
+
+                    const closeError = target.close()
+                    if (closeError) return closeError
+
+                    closed = true
+                    closing = false
+
+                }
+                
+                const value = Reflect.get(target, prop, receiver)
+
+                return typeof value === 'function'
+                    ? value.bind(target)
+                    : value
+                    
+            }
+
+        })
+    }
+
+    /**
+     * Creates an empty node inside the physical filesystem and synchronizes the VFS to match the state.
+     * @param path Path to the node to create.
+     * @param group Group that is creating the node.
+     * @param type Type of node to create.
+     * @param keepPending Whether to keep the node's locked state as "pending"
+     * @returns `[error, null] | [null, FileHandle]`
+     */
+    private async createEmptyNode(path: string, group: string, type: TNode['type'], keepPending?: boolean): T.XEavA<FileHandle, 'L2_NS_CREATE_NODE'> {
+
+        let parentDir: FileHandle | undefined = undefined
+        let parentNode: TDirectory
+
+        const dirname = np.dirname(path)
+        const basename = np.basename(path)
+
+        const abort = async (cause: Error, meta: Record<any, any>) => {
+            await parentDir?.close()
+            if (parentNode.children[basename]) parentNode.children[basename]!.lock = null
+            return IBFSError.eav('L2_NS_CREATE_NODE', null, cause, meta)
+        }
+
+        try {
+
+            const cantCreate = this.vfs.canMakeNode(path, group)    
+            if (cantCreate) return IBFSError.eav('L2_NS_CREATE_NODE', null, cantCreate, { path, group })
+
+            const [resError, $parentNode] = this.vfs.resolveParent(path)
+            if (resError) return IBFSError.eav('L2_NS_CREATE_NODE', null, resError, { path, group })
+            parentNode = $parentNode
+            
+            const [parentError, $parentDir] = await this.open(dirname, group, { mode: 'rw' })
+            if (parentError) return IBFSError.eav('L2_NS_CREATE_NODE', null, parentError, { path, group })
+            parentDir = $parentDir
+
+            const [childError, childAddress] = await this.fs.createEmptyStructure({ type })
+            if (childError) return await abort(childError, { path, group })
+
+            const [dirReadError, dir] = await parentDir.readAsDir()
+            if (dirReadError) return await abort(dirReadError, { path, group })
+
+            dir.children[basename] = childAddress
+
+            const dirWriteError = await parentDir.writeAsDir(dir)
+            if (dirWriteError) return await abort(dirWriteError, { path, group })
+
+            const parentCloseError = await parentDir.close()
+            if (parentCloseError) return await abort(parentCloseError, { path, group })
+
+            parentNode.children[basename] = VFS[type](childAddress)
+            parentNode.children[basename].lock = keepPending ? 'pending' : null
+
+            const [childOpenError, child] = await this.fs.open({ fileAddress: childAddress, mode: 'rw' })
+
+            return childOpenError
+                ? await abort(childOpenError, { path, group })
+                : [null, child]
+
+        } 
+        catch (error) {
+            return IBFSError.eav('L2_NS_CREATE_NODE', null, error as Error, { path, group })    
+        }
+    }
 
 }

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -152,7 +152,7 @@ export default class Namespace {
             // File creation ---------------------------------------------
 
             if (accessError) {
-                if (accessError.code === 'L2_VFS_BAD_PATH' && accessError.meta.missingTarget && options.create && options.mode !== 'r') {
+                if (accessError.code === 'L2_VFS_BAD_PATH' && Object.hasOwn(accessError.meta, 'missingTarget') && options.create && options.mode !== 'r') {
 
                     const cantMake = this.vfs.canMakeNode(path, group)
                     if (cantMake) return IBFSError.eav('L2_NS_OPEN_FILE', null, cantMake, { path, group, options })

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -19,14 +19,14 @@ export interface TDirectory {
     /** Physical address of the directory head block. */ address:   number
     /** User permissions inside the directory         */ perms:     Record<string, TPermLevel>
     /** Children files and subdirectories.            */ children:  Record<string, TNode>
-    /** The handle that's currently holding the lock. */ lock:      WeakRef<FileHandle> | null
+    /** The handle that's currently holding the lock. */ lock:      WeakRef<FileHandle> | 'pending' | null
 }
 
 export interface TFile {
     /** Type of the file structure.                   */ type:      'FILE'
     /** Total size of the file's contents.            */ size:      number
     /** Physical address of the file head block.      */ address:   number
-    /** The handle that's currently holding the lock. */ lock:      WeakRef<FileHandle> | null
+    /** The handle that's currently holding the lock. */ lock:      WeakRef<FileHandle> | 'pending' | null
 }
 
 export type TNode = TDirectory | TFile
@@ -48,7 +48,7 @@ export default class VFS {
 
     // Static ----------------------------------------------------------------------------------------------------------
 
-    public static file(address: number, size = 0): TNode {
+    public static FILE(address: number, size = 0): TNode {
         return {
             type: 'FILE',
             size,
@@ -57,7 +57,7 @@ export default class VFS {
         }
     }
 
-    public static dir(address: number, size = 0): TNode {
+    public static DIR(address: number, size = 0): TNode {
         return {
             type: 'DIR',
             size,
@@ -259,7 +259,7 @@ export default class VFS {
      * @param group Group that is writing the node.
      * @returns `undefined` if the node can be written, or an `IBFSError` if not.
      */
-    public canWriteNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_WRITE_NODE'> {
+    public canWriteNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_WRITE_NODE', { path: string, group: string, missingTarget?: boolean }> {
         try {
         
             let current             = this.tree
@@ -291,7 +291,7 @@ export default class VFS {
             if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
                 
             const newCurrent = current.children[dest]
-            if (!newCurrent) return new IBFSError('L2_VFS_BAD_PATH', `Entry "${dest}" in "${path}" already exists.`, null, { path, group })
+            if (!newCurrent) return new IBFSError('L2_VFS_BAD_PATH', `Entry "${dest}" in "${path}" already exists.`, null, { path, group, missingTarget: true })
 
             // If writing a directory, don't just check write perms on the leading path like 
             // with files, but check write perms inside the target directory as well.

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -291,7 +291,7 @@ export default class VFS {
             if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
                 
             const newCurrent = current.children[dest]
-            if (!newCurrent) return new IBFSError('L2_VFS_BAD_PATH', `Entry "${dest}" in "${path}" already exists.`, null, { path, group, missingTarget: true })
+            if (!newCurrent) return new IBFSError('L2_VFS_BAD_PATH', `Entry "${dest}" in "${path}" does not exist.`, null, { path, group, missingTarget: true })
 
             // If writing a directory, don't just check write perms on the leading path like 
             // with files, but check write perms inside the target directory as well.

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -1,7 +1,3 @@
-// TODO: Add node locking support to VFS in order to reflect file handle locking.
-// This also is required to properly perform recursive checks during deletion to
-// to avoid deleting a parent directory of a currently open file.
-
 // Imports =============================================================================================================
 
 import type * as T from '../../types.js'

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -487,7 +487,7 @@ export default class VFS {
      * @param group The group issuing the action.
      * @returns `undefined` if the node can be deleted, or an `IBFSError` if not.
      */
-    public canDeleteNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_DELETE_NODE' | 'L2_VFS_NO_PERM_NESTED'> {
+    public canDeleteNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_DELETE_NODE' | 'L2_VFS_NO_PERM_NESTED' | 'L2_VFS_LOCKED', { path: string, group: string, deniedChild?: string }> {
         try {
 
             let current             = this.tree
@@ -511,36 +511,65 @@ export default class VFS {
 
             }
 
+            // console.log(current)
+
             // After loop is finished, check if direct parent has write perms:
             if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
                 
             const newCurrent = current.children[dest]
             if (!newCurrent) return new IBFSError('L2_VFS_BAD_PATH', `Entry "${dest}" in "${path}" doesn't exist.`, null, { path, group })
 
+            // console.log(newCurrent)
+
+            if (newCurrent.lock && (newCurrent.lock === 'pending' || newCurrent.lock.deref())) 
+                return new IBFSError('L2_VFS_LOCKED', `Can not delete this item because it is currently accessed elsewhere.`, null, { path, group })
+
             // Perform extra nested checks if the deleted item is a directory.
             // Deleting a directory requires write perms to every subdirectory
             // and file recursively to avoid any partial operations.
-            if (newCurrent.type === 'DIR') {
+            if (newCurrent.type === 'DIR') { 
+
+                // console.log('scanning...')
 
                 perm.progress(newCurrent.perms[group])
                 if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
 
                 let deniedChild: string | null = null
+                let metPresentLock = false
 
                 const scanChildPerms = (dir: TDirectory, pathChunks: string[] = []) => {
                     for (const entry in dir.children) {
                         if (Object.prototype.hasOwnProperty.call(dir.children, entry)) {
+
+                            if (deniedChild) break
                             
                             const child = dir.children[entry]!
-                            if (child.type !== 'DIR') continue
 
-                            perm.progress(child.perms[group])
-                            if (!perm.canWrite) {
-                                if (!deniedChild) deniedChild = pathChunks.join('/') 
-                                break
+                            if (child.type === 'FILE') {
+                                if (child.lock && (child.lock === 'pending' || child.lock.deref())) {
+                                    if (!deniedChild) deniedChild = pathChunks.join('/')
+                                    metPresentLock = true
+                                    break
+                                }
                             }
 
-                            scanChildPerms(child, [...pathChunks, entry])
+                            if (child.type === 'DIR') {
+
+                                perm.progress(child.perms[group])
+                                if (!perm.canWrite) {
+                                    if (!deniedChild) deniedChild = pathChunks.join('/') 
+                                    break
+                                }
+
+                                if (child.lock && (child.lock === 'pending' || child.lock.deref())) {
+                                    if (!deniedChild) deniedChild = pathChunks.join('/')
+                                    metPresentLock = true
+                                    break
+                                }
+
+                                scanChildPerms(child, [...pathChunks, entry])
+
+                            }
 
                         }
                     }
@@ -548,8 +577,10 @@ export default class VFS {
 
                 scanChildPerms(newCurrent, [...parts, dest])
 
-                if (deniedChild) return new IBFSError('L2_VFS_NO_PERM_NESTED', null, null, { path: deniedChild, group })
-
+                if (deniedChild) {
+                    if (metPresentLock) return new IBFSError('L2_VFS_LOCKED', 'Can not delete the directory, at least one of its children is in use elsewhere.', null, { path, group, deniedChild })
+                    else                return new IBFSError('L2_VFS_NO_PERM_NESTED', null, null, { path: deniedChild, group })
+                }
             }
 
             return undefined // Allow access

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -193,15 +193,15 @@ export default class VFS {
 
             // After loop is finished, check if direct parent has write perms:
             if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
+                
+            const newCurrent = current.children[dest]
+            if (newCurrent) return new IBFSError('L2_VFS_ALREADY_EXISTS', `Entry "${dest}" in "${path}" already exists.`, null, { path, group })
 
             const lock = current.lock
             if (lock) {
                 if (lock === 'pending') return new IBFSError('L2_VFS_LOCKED', `Can not create the item because its parent directory is being read/written to.`, null, { path, group, lockPending: true })
                 if (lock.deref())       return new IBFSError('L2_VFS_LOCKED', `Can not create the item because its parent directory is being read/written to..`, null, { path, group })
             }
-                
-            const newCurrent = current.children[dest]
-            if (newCurrent) return new IBFSError('L2_VFS_ALREADY_EXISTS', `Entry "${dest}" in "${path}" already exists.`, null, { path, group })
 
             return undefined // Allow access
 
@@ -372,9 +372,6 @@ export default class VFS {
             // After loop is finished, check if direct parent has write perms:
             if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
 
-            if (current.lock && (current.lock === 'pending' || current.lock.deref())) 
-                return new IBFSError('L2_VFS_LOCKED', `Can not rename this item because it's parent directory is currently in use.`, null, { path, group, lockPending: true })
-
             // Check if source item exists
             const srcNamedItem = current.children[dest]
             if (!srcNamedItem) return new IBFSError('L2_VFS_BAD_PATH', `Entry "${dest}" in "${path}" does not exist.`, null, { path, group })
@@ -382,6 +379,9 @@ export default class VFS {
             // Check if the target name isn't taken
             const destNamedItem = current.children[newName]
             if (destNamedItem) return new IBFSError('L2_VFS_ALREADY_EXISTS', `Entry "${newName}" in "${path}" already exists.`, null, { path, group })
+
+            if (current.lock && (current.lock === 'pending' || current.lock.deref())) 
+                return new IBFSError('L2_VFS_LOCKED', `Can not rename this item because it's parent directory is currently accessed elsewhere.`, null, { path, group, lockPending: true })
             
             return undefined // Allow access
             
@@ -404,7 +404,7 @@ export default class VFS {
      * result    -> /new/path/file.txt
      * ```
      */
-    public canMoveNode(path: string, newParent: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_MOVE_NODE' | 'L2_VFS_ALREADY_EXISTS'> {
+    public canMoveNode(path: string, newParent: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_MOVE_NODE' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean, lockedDir?: 'source' | 'dest' }> {
         try {
 
             let current = this.tree
@@ -437,6 +437,9 @@ export default class VFS {
             const sourceItem = current.children[srcFinal]
             if (!sourceItem) return new IBFSError('L2_VFS_BAD_PATH', `Entry "${srcFinal}" in "${path}" doesn't exists.`, null, { path, group })
 
+            if (current.lock && (current.lock === 'pending' || current.lock.deref())) 
+                return new IBFSError('L2_VFS_LOCKED', `Can not move this item because it's parent directory is currently accessed elsewhere.`, null, { path, group, lockPending: true, lockedDir: 'source' })
+
             // Destination path -----------------------------------------------
 
             current = this.tree
@@ -466,6 +469,9 @@ export default class VFS {
 
             const destItem = current.children[destFinal]
             if (destItem) return new IBFSError('L2_VFS_ALREADY_EXISTS', `Entry "${destFinal}" in "${newParent}" already exists.`, null, { path, group })
+
+            if (current.lock && (current.lock === 'pending' || current.lock.deref())) 
+                return new IBFSError('L2_VFS_LOCKED', `Can not move this item because the destination directory is currently accessed elsewhere.`, null, { path, group, lockPending: true, lockedDir: 'dest' })
 
             return undefined            
             

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -124,14 +124,14 @@ export default class VFS {
      * @param path Path to the node to be resolved.
      * @returns [error, node]
      */
-    public resolve(path: string): T.XEav<TNode, 'L2_VFS_BAD_PATH'> {
+    public resolve(path: string): T.XEav<TNode, 'L2_VFS_BAD_PATH', { path: string, missing: string, missingDirect: boolean }> {
 
         let current: TNode = this.tree
         const parts = VFS.normalizePath(path).split('/').filter(Boolean)
 
         for (const part of parts) {
             const newCurrent = (current as TDirectory).children[part] as TNode | undefined
-            if (!newCurrent) return IBFSError.eav('L2_VFS_BAD_PATH', `Entry "${part}" in "${path}" does not exist.`, null, { path })
+            if (!newCurrent) return IBFSError.eav('L2_VFS_BAD_PATH', `Entry "${part}" in "${path}" does not exist.`, null, { path, missing: part, missingDirect: part === parts[parts.length - 1] })
             current = newCurrent
         }
 

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -163,7 +163,7 @@ export default class VFS {
      * @param group Group that is creating the node.
      * @returns `undefined` if the node can be created, or an `IBFSError` if not.
      */
-    public canMakeNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_CAN_MAKE_NODE' | 'L2_VFS_LOCKED'> {
+    public canMakeNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_CAN_MAKE_NODE' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean }> {
         try {
         
             let current             = this.tree
@@ -193,6 +193,12 @@ export default class VFS {
 
             // After loop is finished, check if direct parent has write perms:
             if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
+
+            const lock = current.lock
+            if (lock) {
+                if (lock === 'pending') return new IBFSError('L2_VFS_LOCKED', `Can not create the item because its parent directory is being read/written to.`, null, { path, group, lockPending: true })
+                if (lock.deref())       return new IBFSError('L2_VFS_LOCKED', `Can not create the item because its parent directory is being read/written to..`, null, { path, group })
+            }
                 
             const newCurrent = current.children[dest]
             if (newCurrent) return new IBFSError('L2_VFS_ALREADY_EXISTS', `Entry "${dest}" in "${path}" already exists.`, null, { path, group })
@@ -211,7 +217,7 @@ export default class VFS {
      * @param group Group that is reading the node.
      * @returns `undefined` if the node can be read, or an `IBFSError` if not.
      */
-    public canReadNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_READ_NODE'> {
+    public canReadNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_READ_NODE' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean }> {
         try {
             
             let current             = this.tree
@@ -243,6 +249,14 @@ export default class VFS {
             if (newCurrent.type === 'DIR') {
                 perm.progress(newCurrent.perms[group])
                 if (!perm.canRead) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
+            }
+
+            const lock = newCurrent.lock
+            if (lock) {
+                // TODO: Read the "pending" lock state upstream and configure a retry within a second or two of the first read attempt
+                if (lock === 'pending') return new IBFSError('L2_VFS_LOCKED', `Can not read the item in the parent directory as it's currently in use.`, null, { path, group, lockPending: true })
+                const ref = lock.deref()
+                if (ref && ref.mode !== 'r') return new IBFSError('L2_VFS_LOCKED', `Can not read the item in the parent directory as it's currently in use.`, null, { path, group })
             }
 
             return undefined // Allow access

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -163,7 +163,7 @@ export default class VFS {
      * @param group Group that is creating the node.
      * @returns `undefined` if the node can be created, or an `IBFSError` if not.
      */
-    public canMakeNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_CAN_MAKE_NODE'> {
+    public canMakeNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_CAN_MAKE_NODE' | 'L2_VFS_LOCKED'> {
         try {
         
             let current             = this.tree
@@ -173,8 +173,10 @@ export default class VFS {
             if (!perm.canRead) return new IBFSError('L2_VFS_NO_PERM',  null, null, { path, group })
             if (!dest)         return new IBFSError('L2_VFS_BAD_PATH', `Can't create item on an empty path.`, null, { path, group })
 
-            for (const part of parts) {
+            for (let i = 0; i < parts.length; i++) {
                 
+                const part = parts[i]!
+                const last = i === parts.length - 1
                 const newCurrent = (current as TDirectory).children[part]
 
                 if (!newCurrent)               return new IBFSError('L2_VFS_BAD_PATH', `Entry "${part}" in "${path}" does not exist.`,     null, { path, group })
@@ -182,6 +184,8 @@ export default class VFS {
 
                 perm.progress(newCurrent.perms[group])
                 if (!perm.canRead) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
+                
+                if (last && newCurrent.lock) return new IBFSError('L2_VFS_LOCKED', 'Can not create the item in the parent directory. The parent is locked.', null, { path, group })
                     
                 current = newCurrent
                 

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -273,7 +273,7 @@ export default class VFS {
      * @param group Group that is writing the node.
      * @returns `undefined` if the node can be written, or an `IBFSError` if not.
      */
-    public canWriteNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_WRITE_NODE', { path: string, group: string, missingTarget?: boolean }> {
+    public canWriteNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_WRITE_NODE' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean, missingTarget?: boolean }> {
         try {
         
             let current             = this.tree
@@ -314,6 +314,12 @@ export default class VFS {
                 if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
             }
 
+            const lock = newCurrent.lock
+            if (lock) {
+                if (lock === 'pending') return new IBFSError('L2_VFS_LOCKED', `Can not write the item because it's currently in use.`, null, { path, group, lockPending: true })
+                if (lock.deref())       return new IBFSError('L2_VFS_LOCKED', `Can not write the item because it's currently in use.`, null, { path, group })
+            }
+
             return undefined // Allow access
 
         } 
@@ -335,7 +341,7 @@ export default class VFS {
      * result  -> /path-to/my/newFile.txt
      * ```
      */
-    public canRenameNode(path: string, newName: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_RENAME_NODE' | 'L2_VFS_ALREADY_EXISTS'> {
+    public canRenameNode(path: string, newName: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_RENAME_NODE' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean }> {
         try {
 
             let current             = this.tree
@@ -365,6 +371,9 @@ export default class VFS {
 
             // After loop is finished, check if direct parent has write perms:
             if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
+
+            if (current.lock && (current.lock === 'pending' || current.lock.deref())) 
+                return new IBFSError('L2_VFS_LOCKED', `Can not rename this item because it's parent directory is currently in use.`, null, { path, group, lockPending: true })
 
             // Check if source item exists
             const srcNamedItem = current.children[dest]

--- a/src/errors/IBFSError.ts
+++ b/src/errors/IBFSError.ts
@@ -269,6 +269,8 @@ const errorCodes = {
     L2_NS_WRITE_FILE:               'Failed to open and write the file.',
     L2_NS_OPEN_WRITE_STREAM:        'Failed to open a file write stream.',
 
+    L2_NS_RENAME:                   'Could not rename the node',
+
     L2_FH_CLOSED:                   'The proxy to this handle has already been closed and can not be used.',
     L2_FH_CLOSING:                  'The proxy to this handle is currently being closed and any further requests must wait until the close is complete.',
     L2_NS_CREATE_NODE:              'Failed to create a node (file or directory)',

--- a/src/errors/IBFSError.ts
+++ b/src/errors/IBFSError.ts
@@ -254,7 +254,7 @@ const errorCodes = {
     L2_VFS_CAN_MOVE_NODE:           'Can not move a node from the source directory to the target directory.',
     L2_VFS_CAN_DELETE_NODE:         'Can not delete a node.',
     L2_VFS_CAN_MANAGE_NODE:         'The group has no permission to manage this node.',
-    L2_VFS_LOCKED:                  'The location is currently locked because it is open elsewhere.',
+    L2_VFS_LOCKED:                  'The location is currently locked because it is open elsewhere. Wait and try in a moment.',
 
     L2_NS_CREATE:                   'Failed to create the filesystem namespace.',
     L2_NS_OPEN:                     'Failed to open the filesystem namespace.',

--- a/src/errors/IBFSError.ts
+++ b/src/errors/IBFSError.ts
@@ -263,11 +263,11 @@ const errorCodes = {
     L2_NS_OPEN_FILE:                'Failed to open a file.',
     L2_NS_LOCKED:                   'The file/directory could not be opened because it is already in use by another consumer.',
 
-    L2_NS_READ:                     'Failed to open and read the file.',
     L2_NS_READ_FILE:                'Failed to open and read the file.',
     L2_NS_OPEN_READ_STREAM:         'Failed to open a file read stream.',
 
-    L2_NS_WRITE:                    'Failed to open and write the file.',
+    L2_NS_WRITE_FILE:               'Failed to open and write the file.',
+    L2_NS_OPEN_WRITE_STREAM:        'Failed to open a file write stream.',
 
     L2_FH_CLOSED:                   'The proxy to this handle has already been closed and can not be used.',
     L2_FH_CLOSING:                  'The proxy to this handle is currently being closed and any further requests must wait until the close is complete.',

--- a/src/errors/IBFSError.ts
+++ b/src/errors/IBFSError.ts
@@ -270,4 +270,6 @@ const errorCodes = {
     L2_FH_CLOSED:                   'The proxy to this handle has already been closed and can not be used.',
     L2_FH_CLOSING:                  'The proxy to this handle is currently being closed and any further requests must wait until the close is complete.',
 
+    L2_NS_CREATE_NODE:              'Failed to create a node (file or directory)',
+
 }

--- a/src/errors/IBFSError.ts
+++ b/src/errors/IBFSError.ts
@@ -254,6 +254,7 @@ const errorCodes = {
     L2_VFS_CAN_MOVE_NODE:           'Can not move a node from the source directory to the target directory.',
     L2_VFS_CAN_DELETE_NODE:         'Can not delete a node.',
     L2_VFS_CAN_MANAGE_NODE:         'The group has no permission to manage this node.',
+    L2_VFS_LOCKED:                  'The location is currently locked because it is open elsewhere.',
 
     L2_NS_CREATE:                   'Failed to create the filesystem namespace.',
     L2_NS_OPEN:                     'Failed to open the filesystem namespace.',

--- a/src/errors/IBFSError.ts
+++ b/src/errors/IBFSError.ts
@@ -264,4 +264,8 @@ const errorCodes = {
     L2_NS_OPEN_FILE:                'Failed to open a file.',
     L2_NS_LOCKED:                   'The file/directory could not be opened because it is already in use by another consumer.',
 
+    L2_NS_READ:                     'Failed to open and read the file.',
+    L2_NS_READ_FILE:                'Failed to open and read the file.',
+    L2_NS_OPEN_READ_STREAM:         'Failed to open a file read stream.',
+
 }

--- a/src/errors/IBFSError.ts
+++ b/src/errors/IBFSError.ts
@@ -267,9 +267,10 @@ const errorCodes = {
     L2_NS_READ_FILE:                'Failed to open and read the file.',
     L2_NS_OPEN_READ_STREAM:         'Failed to open a file read stream.',
 
+    L2_NS_WRITE:                    'Failed to open and write the file.',
+
     L2_FH_CLOSED:                   'The proxy to this handle has already been closed and can not be used.',
     L2_FH_CLOSING:                  'The proxy to this handle is currently being closed and any further requests must wait until the close is complete.',
-
     L2_NS_CREATE_NODE:              'Failed to create a node (file or directory)',
 
 }

--- a/src/errors/IBFSError.ts
+++ b/src/errors/IBFSError.ts
@@ -2,14 +2,14 @@ import type * as T from '../../types.js'
 
 // process.env.IBFS_ERR_TRACE_SIZE = '100'
 
-export default class IBFSError<Code extends IBFSErrorCode = IBFSErrorCode> extends Error {
+export default class IBFSError<Code extends IBFSErrorCode = IBFSErrorCode, ErrorMeta extends Record<any, any> = Record<any, any>> extends Error {
 
     public readonly code: Code
     public readonly causes: Error[] = []
-    public readonly meta: IBFSErrorMetadata = {}
+    public readonly meta: ErrorMeta = {} as Record<any, any>
     public readonly rootCause?: IBFSError
 
-    constructor(code: Code, message?: string | null, cause?: Error | null, meta?: IBFSErrorMetadata) {
+    constructor(code: Code, message?: string | null, cause?: Error | null, meta?: ErrorMeta) {
         
         super(`[${code}] ${message || errorCodes[code]}`)
         this.name = this.constructor.name
@@ -65,8 +65,8 @@ export default class IBFSError<Code extends IBFSErrorCode = IBFSErrorCode> exten
      * Constructs a new IBFSError instance in an Eav (error-as-value) format. 
      * @returns [IBFSError, null]
      */
-    public static eav<Code extends IBFSErrorCode>(code: Code, ...params: T.OmitFirst<ConstructorParameters<typeof IBFSError>>): [IBFSError<Code>, null] {
-        return [new this(code, ...params), null]
+    public static eav<Code extends IBFSErrorCode, ErrorMeta extends Record<any, any>>(code: Code, message?: string | null, cause?: Error | null, meta?: ErrorMeta): [IBFSError<Code, ErrorMeta>, null] {
+        return [new this(code, message, cause, meta), null]
     }
 
     private static trimErrorStack(error: Error, limit = 2) {
@@ -85,7 +85,6 @@ export default class IBFSError<Code extends IBFSErrorCode = IBFSErrorCode> exten
 }
 
 export type IBFSErrorCode = keyof typeof errorCodes
-export type IBFSErrorMetadata = { [key: string]: any }
 
 const errorCodes = {
 

--- a/src/errors/IBFSError.ts
+++ b/src/errors/IBFSError.ts
@@ -268,4 +268,7 @@ const errorCodes = {
     L2_NS_READ_FILE:                'Failed to open and read the file.',
     L2_NS_OPEN_READ_STREAM:         'Failed to open a file read stream.',
 
+    L2_FH_CLOSED:                   'The proxy to this handle has already been closed and can not be used.',
+    L2_FH_CLOSING:                  'The proxy to this handle is currently being closed and any further requests must wait until the close is complete.',
+
 }

--- a/test/L2/namespace.test.ts
+++ b/test/L2/namespace.test.ts
@@ -63,7 +63,7 @@ describe('Namespace', () => {
 
     })
 
-    test('ns.open (create:true)', async () => {
+    test('ns.open (create:true) + write', async () => {
 
         const name = 'l2_open_create'
         const ns = await useEmptyNamespace(name)
@@ -77,8 +77,9 @@ describe('Namespace', () => {
 
         const data = crypto.randomBytes(20_000)
         await uniformSA(h1.writeFile(data))
+        const read = await uniformAsync(h1.readFile())
 
-        expect(await uniformAsync(h1.readFile())).toStrictEqual(data)
+        expect(read).toStrictEqual(data)
 
     })
 

--- a/test/L2/namespace.test.ts
+++ b/test/L2/namespace.test.ts
@@ -126,7 +126,6 @@ describe('Namespace', () => {
 
         const name = 'l2_write_stream'
         const ns = await useEmptyNamespace(name)
-        // console.log(ns.vfs)
 
         const data = crypto.randomBytes(20_000)
 
@@ -136,7 +135,6 @@ describe('Namespace', () => {
         stream.end()
 
         await new Promise<void>(resolve => stream.on('finish', resolve))
-
 
         const read = await uniformAsync(ns.readFile('/file.txt', '000000'))
         expect(read).toStrictEqual(data)

--- a/test/L2/namespace.test.ts
+++ b/test/L2/namespace.test.ts
@@ -41,7 +41,7 @@ describe('Namespace', () => {
 
     test('ns.open/fh.close - Caching, locking & reference counting.', async () => {
 
-        const name = 'l2_close'
+        const name = 'l2_open_caching'
 
         const ns = await useEmptyNamespace(name)
         const h1 = await uniformAsync(ns.open('/', '000000', { mode: 'r' }))
@@ -65,7 +65,7 @@ describe('Namespace', () => {
 
     test('ns.open (create:true)', async () => {
 
-        const name = 'l2_close'
+        const name = 'l2_open_create'
         const ns = await useEmptyNamespace(name)
 
         const h1 = await uniformAsync(ns.open('/file.txt', '000000', { mode: 'rw', create: true }))
@@ -80,7 +80,50 @@ describe('Namespace', () => {
 
         expect(await uniformAsync(h1.readFile())).toStrictEqual(data)
 
+    })
+
+    test('ns.writeFile/readFile', async () => {
+
+        const name = 'l2_write_file'
+        const ns = await useEmptyNamespace(name)
+
+        const data = crypto.randomBytes(20_000)
+
+        const err1         = await ns.writeFile('/file.txt', '000000', data)
+        const [err2, read] = await ns.readFile('/file.txt',  '000000')
+
+        expect(err1).toBe(undefined)
+        expect(err2).toBe(null)
+        expect(read).toStrictEqual(data)
 
     })
+
+    test('ns.createReadStream', async () => {
+
+        const name = 'l2_read_stream'
+        const ns = await useEmptyNamespace(name)
+
+        const data = crypto.randomBytes(20_000)
+
+        const err1 = await ns.writeFile('/file.txt', '000000', data)
+        expect(err1).toBe(undefined)
+
+        const stream = await uniformAsync(ns.createReadStream('/file.txt', '000000'))
+
+        const read = Buffer.alloc(20_000)
+        let index = 0
+
+        for await (const chunk of stream) {
+            chunk.copy(read, index)
+            index += chunk.length
+        }
+
+        expect(read).toStrictEqual(data)
+
+    })
+
+
      
 })
+
+

--- a/test/L2/namespace.test.ts
+++ b/test/L2/namespace.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect } from "vitest"
-import { uniform, uniformAsync, uniformSA } from "../libs/uniform.js"
+import { uniform, uniformAsync, uniformS, uniformSA } from "../libs/uniform.js"
 import { emptyNamespace } from "../libs/empty-namespace.js"
 import BlockAESContext from "../../src/L0/BlockAES.js"
+import IBFSError from "../../src/errors/IBFSError.js"
 
 describe('Namespace', () => {
 
@@ -15,11 +16,11 @@ describe('Namespace', () => {
         rootGroup: '000000'
     })
 
-    // test('ns.createEmptyNamespace', async () => {
-    //     const name = 'l2_empty_namespace'
-    //     const ns = await useEmptyNamespace(name)
-    //     expect(ns).not.toBeNull()
-    // })
+    test('ns.createEmptyNamespace', async () => {
+        const name = 'l2_empty_namespace'
+        const ns = await useEmptyNamespace(name)
+        expect(ns).not.toBeNull()
+    })
 
     test('ns.open', async () => {
 
@@ -34,6 +35,30 @@ describe('Namespace', () => {
             users: { '000000': 4 },
             meta: {}
         })
+
+    })
+
+    test('ns.open/fh.close - Caching, locking & reference counting.', async () => {
+
+        const name = 'l2_close'
+
+        const ns = await useEmptyNamespace(name)
+        const h1 = await uniformAsync(ns.open('/', '000000', { mode: 'r' }))
+        const h2 = await uniformAsync(ns.open('/', '000000', { mode: 'r' }))
+        
+        const [h3e, h3] = await ns.open('/', '000000', { mode: 'w' })
+        expect(h3e).toBeInstanceOf(IBFSError)
+        expect(h3e?.has('L2_NS_LOCKED')).toBe(true)
+
+        // @ts-ignore
+        expect(ns.fs._rh._meta.get(h1.fbm.startingAddress)?.refCount).toBe(2)
+
+        await expect(h1.close()).resolves.toBeUndefined()
+        await expect(h1.close()).resolves.instanceOf(IBFSError)
+        // @ts-ignore
+        expect(ns.fs._rh._meta.get(h1.fbm.startingAddress)?.refCount).toBe(1)
+
+        await expect(h2.close()).resolves.toBeUndefined()
 
     })
      

--- a/test/L2/namespace.test.ts
+++ b/test/L2/namespace.test.ts
@@ -29,8 +29,6 @@ describe('Namespace', () => {
         const handle    = await uniformAsync(ns.open('/', '000000', { mode: 'r' }))
         const rootDir   = await uniformAsync(handle.readAsDir())
 
-        console.log(handle)
-
         expect(rootDir).toStrictEqual({
             children: {},
             users: { '000000': 4 },

--- a/test/L2/namespace.test.ts
+++ b/test/L2/namespace.test.ts
@@ -3,6 +3,7 @@ import { uniform, uniformAsync, uniformS, uniformSA } from "../libs/uniform.js"
 import { emptyNamespace } from "../libs/empty-namespace.js"
 import BlockAESContext from "../../src/L0/BlockAES.js"
 import IBFSError from "../../src/errors/IBFSError.js"
+import crypto from 'node:crypto'
 
 describe('Namespace', () => {
 
@@ -59,6 +60,26 @@ describe('Namespace', () => {
         expect(ns.fs._rh._meta.get(h1.fbm.startingAddress)?.refCount).toBe(1)
 
         await expect(h2.close()).resolves.toBeUndefined()
+
+    })
+
+    test('ns.open (create:true)', async () => {
+
+        const name = 'l2_close'
+        const ns = await useEmptyNamespace(name)
+
+        const h1 = await uniformAsync(ns.open('/file.txt', '000000', { mode: 'rw', create: true }))
+        const [err2, h2]      = await ns.open('/file.txt', '000000', { mode: 'rw', create: true })
+
+        // @ts-ignore
+        expect(ns.vfs.tree.children['file.txt']).not.toBeUndefined()
+        expect(err2!.has('L2_NS_LOCKED')).toBe(true)
+
+        const data = crypto.randomBytes(20_000)
+        await uniformSA(h1.writeFile(data))
+
+        expect(await uniformAsync(h1.readFile())).toStrictEqual(data)
+
 
     })
      

--- a/test/L2/namespace.test.ts
+++ b/test/L2/namespace.test.ts
@@ -122,6 +122,27 @@ describe('Namespace', () => {
 
     })
 
+    test('ns.createWriteStream', async () => {
+
+        const name = 'l2_write_stream'
+        const ns = await useEmptyNamespace(name)
+        // console.log(ns.vfs)
+
+        const data = crypto.randomBytes(20_000)
+
+        const stream = await uniformAsync(ns.createWriteStream('/file.txt', '000000'))
+        
+        stream.write(data)
+        stream.end()
+
+        await new Promise<void>(resolve => stream.on('finish', resolve))
+
+
+        const read = await uniformAsync(ns.readFile('/file.txt', '000000'))
+        expect(read).toStrictEqual(data)
+
+    })
+
 
      
 })

--- a/test/L2/vfs.test.ts
+++ b/test/L2/vfs.test.ts
@@ -55,6 +55,12 @@ describe('Virtual Filesystem', () => {
                     },
                 },
             },
+            'locked-file': {
+                type: 'FILE',
+                size: 1400,
+                address: 10,
+                lock: 'pending',
+            }
         }
 
         // Root directory
@@ -77,6 +83,9 @@ describe('Virtual Filesystem', () => {
         // Nested folder whose parent has denied permissions
         expect(vfs.canReadNode('/folder1/folder2/folder3/', 'group1')).toBeInstanceOf(IBFSError)
         expect(vfs.canReadNode('/folder1/folder2/folder3/', 'group2')!.has('L2_VFS_NO_PERM')).toBe(true)
+
+        // Respect file locks
+        expect(vfs.canReadNode('/locked-file', 'group1')!.has('L2_VFS_LOCKED')).toBe(true)
 
     })
 
@@ -104,6 +113,12 @@ describe('Virtual Filesystem', () => {
                         lock: null,
                     }
                 }
+            },
+            'locked-file': {
+                type: 'FILE',
+                size: 1400,
+                address: 10,
+                lock: 'pending',
             }
         }
 
@@ -121,6 +136,10 @@ describe('Virtual Filesystem', () => {
 
         // Nested file with denied parent
         expect(vfs.canWriteNode('/folder1/file2.txt', 'group2')!.has('L2_VFS_NO_PERM')).toBe(true)
+
+        // Respect file locks
+        expect(vfs.canWriteNode('/locked-file', 'group1')!.has('L2_VFS_NO_PERM')).toBe(true)
+        expect(vfs.canWriteNode('/locked-file', 'group2')!.has('L2_VFS_LOCKED')).toBe(true)
 
     })
 
@@ -255,6 +274,21 @@ describe('Virtual Filesystem', () => {
                     }
                 }
             },
+            'locked-dir': {
+                type: 'DIR',
+                size: 1400,
+                address: 10,
+                lock: 'pending',
+                perms: {},
+                children: {
+                    'file2.txt': {
+                        type: 'FILE',
+                        size: 5000,
+                        address: 30,
+                        lock: null,
+                    }
+                }
+            }
         }
 
         // Rename root directory
@@ -270,6 +304,9 @@ describe('Virtual Filesystem', () => {
 
         // Rename to an already taken name
         expect(vfs.canRenameNode('file1.txt', 'folder1', 'group2')!.has('L2_VFS_ALREADY_EXISTS')).toBe(true)
+
+        // Respect file locks
+        expect(vfs.canRenameNode('/locked-dir/file2.txt', 'new-name', 'group2')!.has('L2_VFS_LOCKED')).toBe(true)
 
     })
 

--- a/test/L2/vfs.test.ts
+++ b/test/L2/vfs.test.ts
@@ -439,7 +439,22 @@ describe('Virtual Filesystem', () => {
                         lock: null,
                     }
                 }
-            }
+            },
+            'locked-dir': {
+                type: 'DIR',
+                size: 1400,
+                address: 10,
+                lock: null,
+                perms: {},
+                children: {
+                    'file2.txt': {
+                        type: 'FILE',
+                        size: 5000,
+                        address: 30,
+                        lock: 'pending'
+                    }
+                }
+            },
         }
 
         // Delete root directory
@@ -463,6 +478,9 @@ describe('Virtual Filesystem', () => {
         // Delete folder with children the user doesn't have write access to
         expect(vfs.canDeleteNode('/folder1', 'group2')!.has('L2_VFS_NO_PERM_NESTED')).toBe(true)
 
+        // Respect file locks
+        expect(vfs.canDeleteNode('/locked-dir/file2.txt', 'group2')!.has('L2_VFS_LOCKED')).toBe(true)
+        expect(vfs.canDeleteNode('/locked-dir',           'group2')!.has('L2_VFS_LOCKED')).toBe(true)
 
     })
 

--- a/test/L2/vfs.test.ts
+++ b/test/L2/vfs.test.ts
@@ -149,6 +149,14 @@ describe('Virtual Filesystem', () => {
                     }
                 }
             },
+            'folder2': {
+                type: 'DIR',
+                size: 0,
+                address: 40,
+                perms: {},
+                lock: 'pending',
+                children: {}
+            }
         }
 
         // Root directory
@@ -171,6 +179,9 @@ describe('Virtual Filesystem', () => {
         // Nested file with denied parent
         expect(vfs.canMakeNode('/folder1/file3.txt', 'group2')).toBe(undefined)
         expect(vfs.canMakeNode('/folder1/file3.txt', 'group3')!.has('L2_VFS_NO_PERM')).toBe(true)
+
+        // Respect the parent directory of the to-be-created node's parent directory.
+        expect(vfs.canMakeNode('/folder2/file.txt', 'group2')!.has('L2_VFS_LOCKED')).toBe(true)
 
 
     })

--- a/test/L2/vfs.test.ts
+++ b/test/L2/vfs.test.ts
@@ -199,7 +199,7 @@ describe('Virtual Filesystem', () => {
         expect(vfs.canMakeNode('/folder1/file3.txt', 'group2')).toBe(undefined)
         expect(vfs.canMakeNode('/folder1/file3.txt', 'group3')!.has('L2_VFS_NO_PERM')).toBe(true)
 
-        // Respect the parent directory of the to-be-created node's parent directory.
+        // Respect file locks
         expect(vfs.canMakeNode('/folder2/file.txt', 'group2')!.has('L2_VFS_LOCKED')).toBe(true)
 
 
@@ -361,7 +361,22 @@ describe('Virtual Filesystem', () => {
                         lock: null,
                     }
                 }
-            }
+            },
+            'locked-dir': {
+                type: 'DIR',
+                size: 1400,
+                address: 10,
+                lock: 'pending',
+                perms: {},
+                children: {
+                    'file2.txt': {
+                        type: 'FILE',
+                        size: 5000,
+                        address: 30,
+                        lock: null,
+                    }
+                }
+            },
         }
 
         // Move root directory
@@ -378,6 +393,17 @@ describe('Virtual Filesystem', () => {
 
         // Move item to a directory with an item of the same name
         expect(vfs.canMoveNode('/folder1/file4.txt', '/folder2', 'group2')!.has('L2_VFS_ALREADY_EXISTS')).toBe(true)
+
+        // Respect file locks
+        const op1 = vfs.canMoveNode('/file1.txt', '/locked-dir/', 'group2')!
+        expect(op1.has('L2_VFS_LOCKED')).toBe(true)
+        expect(op1.meta.lockPending).toBe(true)
+        expect(op1.meta.lockedDir).toBe('dest')
+
+        const op2 = vfs.canMoveNode('/locked-dir/file2.txt', '/folder2', 'group2')!
+        expect(op2.has('L2_VFS_LOCKED')).toBe(true)
+        expect(op2.meta.lockPending).toBe(true)
+        expect(op2.meta.lockedDir).toBe('source')
 
     })
 

--- a/test/libs/uniform.ts
+++ b/test/libs/uniform.ts
@@ -12,6 +12,10 @@ export async function uniformAsync<V, E extends Error>(promise: T.EavA<V, E>): P
     return value!
 }
 
+export function uniformS<E extends Error>(error: T.EavS<E>): void {
+    if (error) throw error
+}
+
 export async function uniformSA<E extends Error>(promise: T.EavSA<E>): Promise<void> {
     const error = await promise
     if (error) throw error

--- a/types.d.ts
+++ b/types.d.ts
@@ -5,38 +5,38 @@ import IBFSError, { IBFSErrorCode } from './src/errors/IBFSError.js'
  * throwing errors, which generally produces messy control flow.
  */
 export type Eav<V, E extends Error = Error> = [E, null] | [null, V]
-export type XEav<V, EC extends IBFSErrorCode> = [IBFSError<EC>, null] | [null, V]
+export type XEav<V, EC extends IBFSErrorCode, M extends Record<any, any> = Record<any, any>> = [IBFSError<EC, M>, null] | [null, V]
 
 /**
  * Similar to Eav, but does not enforce either error or value.
  * Both are returned to allow for more graceful error handling.
  */
 export type EavG<V, E extends Error = Error> = [E, null]
-export type XEavG<V, EC extends IBFSErrorCode> = [IBFSError<EC>, null]
+export type XEavG<V, EC extends IBFSErrorCode, M extends Record<any, any> = Record<any, any>> = [IBFSError<EC, M>, null]
 
 /**
  * Async implementation of `Eav<value, error>`
  */
 export type EavA<V, E extends Error = Error> = Promise<Eav<V, E>>
-export type XEavA<V, EC extends IBFSErrorCode> = Promise<XEav<V, EC>>
+export type XEavA<V, EC extends IBFSErrorCode, M extends Record<any, any> = Record<any, any>> = Promise<XEav<V, EC, M>>
 
 /**
  * Single-value procedural function return type.
  */
 export type EavS<E extends Error = Error> = E | void
-export type XEavS<EC extends IBFSErrorCode> = IBFSError<EC> | void
+export type XEavS<EC extends IBFSErrorCode, M extends Record<any, any> = Record<any, any>> = IBFSError<EC, M> | void
 
 /** 
  * Async implementation of `EavS<error>`.
 */
 export type EavSA<E extends Error = Error> = Promise<EavS<E>>
-export type XEavSA<EC extends IBFSErrorCode> = Promise<XEavS<EC>>
+export type XEavSA<EC extends IBFSErrorCode, M extends Record<any, any> = Record<any, any>> = Promise<XEavS<EC, M>>
 
 /** 
  * Async implementation of `EavG<error>`.
 */
 export type EavGA<V, E extends Error = Error> = Promise<[E, null]>
-export type XEavGA<V, EC extends IBFSErrorCode> = Promise<[IBFSError<EC>, null]>
+export type XEavGA<V, EC extends IBFSErrorCode, M extends Record<any, any> = Record<any, any>> = Promise<[IBFSError<EC, M>, null]>
 
 /**
  * Excludes the first constructor parameter.


### PR DESCRIPTION
- VFS class methods now respect pending and active locks represented in the virtual filesystem tree.
- NS.open now retries to open in read-only mode when it encounters a pending lock in the VFS.