### PR TITLE
Feat/vfs lock checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -790,6 +790,7 @@
       "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1166,6 +1167,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1375,6 +1377,7 @@
       "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/src/L1/caching/InstanceRegistry.ts
+++ b/src/L1/caching/InstanceRegistry.ts
@@ -1,8 +1,10 @@
+// TODO: Refactor the entire registry to use a single map for both metadata and references
+// in order to simplify its logic.
+
 // Imports =============================================================================================================
 
 import { styleText } from "node:util"
 import { toGridString } from "../../misc/toGridString.js"
-
 
 // Types ===============================================================================================================
 

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -152,6 +152,7 @@ export default class Namespace {
             // File creation ---------------------------------------------
 
             if (accessError) {
+                if (accessError.code === 'L2_VFS_LOCKED') return IBFSError.eav('L2_NS_LOCKED', null, accessError, { path, group, options })
                 if (accessError.code === 'L2_VFS_BAD_PATH' && Object.hasOwn(accessError.meta, 'missingTarget') && options.create && options.mode !== 'r') {
 
                     const cantMake = this.vfs.canMakeNode(path, group)

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -21,35 +21,32 @@ export interface TNSInit extends TFSInit {
 
 // Base options --------------------------------------------------------------------------------------------------------
 
-interface BaseReadOptions {
+interface TBaseOpenOptions {
+    /** How many times to retry opening the file if it fails due to a pending lock elsewhere. @default 3 */ 
+    retry?: number
+    /** How many milliseconds to wait between retries. @default 300 */
+    retryEvery?: number
+}
+
+interface TBaseReadOptions {
     /** Whether to perform data integrity checks during reads. */ integrity?: boolean
 }
 
-export interface TNSOpenOptions extends Omit<TFSOpenFile, 'fileAddress'> {
-    /** Whether to create the file if it does not exist. */ create?: boolean
-}
-
-// export interface TNSReadOptions extends BaseReadOptions {
-//     /** Offset from start of the file to begin reading from. */ offset?: number
-//     /** Number of bytes to read from the offset.             */ length: number
-// }
-
-export interface TNSReadFileOptions       extends BaseReadOptions              {}
-export interface TNSOpenReadStreamOptions extends BaseReadOptions, TFRSOptions {}
-
-export interface TNSWriteFileOptions {
-    /** 
-     * Whether to create the file if it does not exist.
-     * @default true
-     */ 
+export interface TNSOpenOptions extends TBaseOpenOptions, Omit<TFSOpenFile, 'fileAddress'> {
+    /** Whether to create the file if it does not exist. */ 
     create?: boolean
 }
 
-export interface TNSOpenWriteStreamOptions extends TFWSOptions, Pick<TFSOpenFile, 'append' | 'truncate'> {
-    /** 
-     * Whether to create the file if it does not exist.
-     * @default true
-     */ 
+export interface TNSReadFileOptions       extends TBaseOpenOptions, TBaseReadOptions              {}
+export interface TNSOpenReadStreamOptions extends TBaseOpenOptions, TBaseReadOptions, TFRSOptions {}
+
+export interface TNSWriteFileOptions extends TBaseOpenOptions {
+    /**  Whether to create the file if it does not exist. @default true */ 
+    create?: boolean
+}
+
+export interface TNSOpenWriteStreamOptions extends TBaseOpenOptions, TFWSOptions, Pick<TFSOpenFile, 'append' | 'truncate'> {
+    /**  Whether to create the file if it does not exist. @default true */ 
     create?: boolean
 }
 
@@ -128,7 +125,7 @@ export default class Namespace {
     // IO methods ------------------------------------------------------------------------------------------------------
 
     /**
-     * Opens the file on a specific `path` file and returns its handle. If the file is being used by another user that
+     * Opens the file on a specific `path` and returns its handle. If the file is being used by another user in a way that
      * conflicts with the action of opening a new handle, the call will fail and return an error. The same file can be
      * open multiple times by different users in read-only mode, but only by a single user in write mode which requires
      * absolute exclusive access.
@@ -142,82 +139,101 @@ export default class Namespace {
      * @param options.integrity Whether to perform data integrity checks.
      * @returns `[error, null] | [null, handle]`
      */
-    public async open(path: string, group: string, options: TNSOpenOptions): T.XEavA<FileHandle, 'L2_NS_OPEN_FILE' | 'L2_NS_NO_PERM' | 'L2_NS_LOCKED'> {
+    public async open(path: string, group: string, options: TNSOpenOptions): T.XEavA<FileHandle, 'L2_NS_OPEN_FILE' | 'L2_NS_NO_PERM' | 'L2_NS_LOCKED', { lockPending?: true }> {
         try {
 
-            const accessError = options.mode === 'r'
-                ? this.vfs.canReadNode(path, group)
-                : this.vfs.canWriteNode(path, group)
+            const maxRetries = options.retry || 3
+            const retryEvery = options.retryEvery || 300
 
-            // File creation ---------------------------------------------
+            const open = async (count: number = 0): Promise<ReturnType<typeof this.open>> => {
 
-            if (accessError) {
-                if (accessError.code === 'L2_VFS_LOCKED') return IBFSError.eav('L2_NS_LOCKED', null, accessError, { path, group, options })
-                if (accessError.code === 'L2_VFS_BAD_PATH' && Object.hasOwn(accessError.meta, 'missingTarget') && options.create && options.mode !== 'r') {
+                const accessError = options.mode === 'r'
+                    ? this.vfs.canReadNode(path, group)
+                    : this.vfs.canWriteNode(path, group)
 
-                    const cantMake = this.vfs.canMakeNode(path, group)
-                    if (cantMake) return IBFSError.eav('L2_NS_OPEN_FILE', null, cantMake, { path, group, options })
-                    
-                    const [createError, fileHandle] = await this.createEmptyNode(path, group, 'FILE')
-                    if (createError) return IBFSError.eav('L2_NS_OPEN_FILE', null, createError, { path, group, options })
-                    
-                    const [resolveError, fileNode] = this.vfs.resolve(path)
-                    if (resolveError) {
-                        await fileHandle.close()
-                        return IBFSError.eav('L2_NS_OPEN_FILE', null, resolveError, { path, group, options })
+                // File creation ---------------------------------------------
+
+                if (accessError) {
+
+                    if (accessError.code === 'L2_VFS_LOCKED') {
+                        // Retry X times if opening in read mode and file lock is pending.
+                        if (options.mode === 'r' && accessError.meta.lockPending && count < maxRetries) {
+                            await new Promise(resolve => setTimeout(resolve, retryEvery))
+                            return await open(count + 1)
+                        }
+                        return IBFSError.eav('L2_NS_LOCKED', null, accessError, { lockPending: true })
                     }
 
-                    fileNode.lock = new WeakRef(fileHandle)
-                    fileHandle.on('close', () => fileNode.lock = null)
+                    if (accessError.code === 'L2_VFS_BAD_PATH' && Object.hasOwn(accessError.meta, 'missingTarget') && options.create && options.mode !== 'r') {
 
-                    const proxy = this.createHandleProxy(fileHandle)
-                    return [null, proxy]
+                        const cantMake = this.vfs.canMakeNode(path, group)
+                        if (cantMake) return IBFSError.eav('L2_NS_OPEN_FILE', null, cantMake)
+                        
+                        const [createError, fileHandle] = await this.createEmptyNode(path, group, 'FILE')
+                        if (createError) return IBFSError.eav('L2_NS_OPEN_FILE', null, createError)
+                        
+                        const [resolveError, fileNode] = this.vfs.resolve(path)
+                        if (resolveError) {
+                            await fileHandle.close()
+                            return IBFSError.eav('L2_NS_OPEN_FILE', null, resolveError)
+                        }
+
+                        fileNode.lock = new WeakRef(fileHandle)
+                        fileHandle.on('close', () => fileNode.lock = null)
+
+                        const proxy = this.createHandleProxy(fileHandle)
+                        return [null, proxy]
+
+                    }
+                    else return IBFSError.eav('L2_NS_OPEN_FILE', null, accessError)
 
                 }
-                else return IBFSError.eav('L2_NS_OPEN_FILE', null, accessError, { path, group, options })
-            }
 
-            // -----------------------------------------------------------
+                // -----------------------------------------------------------
 
-            const [resolveError, vfsNode] = this.vfs.resolve(path)
-            if (resolveError) return IBFSError.eav('L2_NS_OPEN_FILE', null, resolveError, { path, group, options })
+                const [resolveError, vfsNode] = this.vfs.resolve(path)
+                if (resolveError) return IBFSError.eav('L2_NS_OPEN_FILE', null, resolveError)
 
-            const handle = vfsNode.lock && vfsNode.lock !== 'pending' && vfsNode.lock.deref()
+                const handle = vfsNode.lock && vfsNode.lock !== 'pending' && vfsNode.lock.deref()
 
-            // No existing handle, resource is free, open straight away and lock it.
-            if (!handle) {
-
-                const [openError, handle] = await this.fs.open({ fileAddress: vfsNode.address, ...options })
-                if (openError) return IBFSError.eav('L2_NS_OPEN_FILE', null, openError, { path, group, options })
-
-                vfsNode.lock = new WeakRef(handle)
-                handle.on('close', () => vfsNode.lock = null)
-
-                const proxy = this.createHandleProxy(handle)
-                return [null, proxy]
-
-            }
-            // The resource is locked by another user.
-            else {
-
-                // Reuse/share a read-only handle if one exists (done internally)
-                if (options.mode === 'r' && handle.mode === 'r') {
+                // No existing handle, resource is free, open straight away and lock it.
+                if (!handle) {
 
                     const [openError, handle] = await this.fs.open({ fileAddress: vfsNode.address, ...options })
-                    if (openError) return IBFSError.eav('L2_NS_OPEN_FILE', null, openError, { path, group, options })
+                    if (openError) return IBFSError.eav('L2_NS_OPEN_FILE', null, openError)
+
+                    vfsNode.lock = new WeakRef(handle)
+                    handle.on('close', () => vfsNode.lock = null)
 
                     const proxy = this.createHandleProxy(handle)
                     return [null, proxy]
 
                 }
-                // Return an error if the file is locked by another user in write mode.
-                else return IBFSError.eav('L2_NS_LOCKED', null, null, { path, group, options })
+                // The resource is locked by another user.
+                else {
+
+                    // Reuse/share a read-only handle if one exists (done internally)
+                    if (options.mode === 'r' && handle.mode === 'r') {
+
+                        const [openError, handle] = await this.fs.open({ fileAddress: vfsNode.address, ...options })
+                        if (openError) return IBFSError.eav('L2_NS_OPEN_FILE', null, openError)
+
+                        const proxy = this.createHandleProxy(handle)
+                        return [null, proxy]
+
+                    }
+                    // Return an error if the file is locked by another user in write mode.
+                    else return IBFSError.eav('L2_NS_LOCKED', null, null)
+
+                }
 
             }
+
+            return await open()
             
         } 
         catch (error) {
-            return IBFSError.eav('L2_NS_OPEN_FILE', null, error as Error, { path, group, options })
+            return IBFSError.eav('L2_NS_OPEN_FILE', null, error as Error)
         }
     }
 

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -1,14 +1,17 @@
 // Imports =============================================================================================================
 
 import type * as T from '../../types.js'
-import IBFSError from '../errors/IBFSError.js'
-import FileHandle from '../L1/file/FileHandle.js'
-import FileReadStream, { TFRSOptions } from '../L1/file/FileReadStream.js'
-import FileWriteStream, { TFWSOptions } from '../L1/file/FileWriteStream.js'
-import Filesystem, { TFSInit, TFSOpenFile } from '../L1/Filesystem.js'
-import ssc from '../misc/safeShallowCopy.js'
-import VFS, { TDirectory, TNode } from './VirtualFilesystem.js'
-import np from 'node:path'
+
+import IBFSError                                from '../errors/IBFSError.js'
+import FileHandle                               from '../L1/file/FileHandle.js'
+import FileReadStream, { TFRSOptions }          from '../L1/file/FileReadStream.js'
+import FileWriteStream, { TFWSOptions }         from '../L1/file/FileWriteStream.js'
+import Filesystem, { TFSInit, TFSOpenFile }     from '../L1/Filesystem.js'
+
+import ssc                                      from '../misc/safeShallowCopy.js'
+import VFS, { TDirectory, TNode }               from './VirtualFilesystem.js'
+
+import np                                       from 'node:path'
 
 // Types ===============================================================================================================
 

--- a/src/L2/Namespace.ts
+++ b/src/L2/Namespace.ts
@@ -152,7 +152,7 @@ export default class Namespace {
             // File creation ---------------------------------------------
 
             if (accessError) {
-                if (accessError.code === 'L2_VFS_BAD_PATH' && accessError.meta.missingTarget && options.create && options.mode !== 'r') {
+                if (accessError.code === 'L2_VFS_BAD_PATH' && Object.hasOwn(accessError.meta, 'missingTarget') && options.create && options.mode !== 'r') {
 
                     const cantMake = this.vfs.canMakeNode(path, group)
                     if (cantMake) return IBFSError.eav('L2_NS_OPEN_FILE', null, cantMake, { path, group, options })

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -487,7 +487,7 @@ export default class VFS {
      * @param group The group issuing the action.
      * @returns `undefined` if the node can be deleted, or an `IBFSError` if not.
      */
-    public canDeleteNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_DELETE_NODE' | 'L2_VFS_NO_PERM_NESTED'> {
+    public canDeleteNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_DELETE_NODE' | 'L2_VFS_NO_PERM_NESTED' | 'L2_VFS_LOCKED', { path: string, group: string, deniedChild?: string }> {
         try {
 
             let current             = this.tree
@@ -511,36 +511,65 @@ export default class VFS {
 
             }
 
+            // console.log(current)
+
             // After loop is finished, check if direct parent has write perms:
             if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
                 
             const newCurrent = current.children[dest]
             if (!newCurrent) return new IBFSError('L2_VFS_BAD_PATH', `Entry "${dest}" in "${path}" doesn't exist.`, null, { path, group })
 
+            // console.log(newCurrent)
+
+            if (newCurrent.lock && (newCurrent.lock === 'pending' || newCurrent.lock.deref())) 
+                return new IBFSError('L2_VFS_LOCKED', `Can not delete this item because it is currently accessed elsewhere.`, null, { path, group })
+
             // Perform extra nested checks if the deleted item is a directory.
             // Deleting a directory requires write perms to every subdirectory
             // and file recursively to avoid any partial operations.
-            if (newCurrent.type === 'DIR') {
+            if (newCurrent.type === 'DIR') { 
+
+                // console.log('scanning...')
 
                 perm.progress(newCurrent.perms[group])
                 if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
 
                 let deniedChild: string | null = null
+                let metPresentLock = false
 
                 const scanChildPerms = (dir: TDirectory, pathChunks: string[] = []) => {
                     for (const entry in dir.children) {
                         if (Object.prototype.hasOwnProperty.call(dir.children, entry)) {
+
+                            if (deniedChild) break
                             
                             const child = dir.children[entry]!
-                            if (child.type !== 'DIR') continue
 
-                            perm.progress(child.perms[group])
-                            if (!perm.canWrite) {
-                                if (!deniedChild) deniedChild = pathChunks.join('/') 
-                                break
+                            if (child.type === 'FILE') {
+                                if (child.lock && (child.lock === 'pending' || child.lock.deref())) {
+                                    if (!deniedChild) deniedChild = pathChunks.join('/')
+                                    metPresentLock = true
+                                    break
+                                }
                             }
 
-                            scanChildPerms(child, [...pathChunks, entry])
+                            if (child.type === 'DIR') {
+
+                                perm.progress(child.perms[group])
+                                if (!perm.canWrite) {
+                                    if (!deniedChild) deniedChild = pathChunks.join('/') 
+                                    break
+                                }
+
+                                if (child.lock && (child.lock === 'pending' || child.lock.deref())) {
+                                    if (!deniedChild) deniedChild = pathChunks.join('/')
+                                    metPresentLock = true
+                                    break
+                                }
+
+                                scanChildPerms(child, [...pathChunks, entry])
+
+                            }
 
                         }
                     }
@@ -548,8 +577,10 @@ export default class VFS {
 
                 scanChildPerms(newCurrent, [...parts, dest])
 
-                if (deniedChild) return new IBFSError('L2_VFS_NO_PERM_NESTED', null, null, { path: deniedChild, group })
-
+                if (deniedChild) {
+                    if (metPresentLock) return new IBFSError('L2_VFS_LOCKED', 'Can not delete the directory, at least one of its children is in use elsewhere.', null, { path, group, deniedChild })
+                    else                return new IBFSError('L2_VFS_NO_PERM_NESTED', null, null, { path: deniedChild, group })
+                }
             }
 
             return undefined // Allow access

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -193,15 +193,15 @@ export default class VFS {
 
             // After loop is finished, check if direct parent has write perms:
             if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
+                
+            const newCurrent = current.children[dest]
+            if (newCurrent) return new IBFSError('L2_VFS_ALREADY_EXISTS', `Entry "${dest}" in "${path}" already exists.`, null, { path, group })
 
             const lock = current.lock
             if (lock) {
                 if (lock === 'pending') return new IBFSError('L2_VFS_LOCKED', `Can not create the item because its parent directory is being read/written to.`, null, { path, group, lockPending: true })
                 if (lock.deref())       return new IBFSError('L2_VFS_LOCKED', `Can not create the item because its parent directory is being read/written to..`, null, { path, group })
             }
-                
-            const newCurrent = current.children[dest]
-            if (newCurrent) return new IBFSError('L2_VFS_ALREADY_EXISTS', `Entry "${dest}" in "${path}" already exists.`, null, { path, group })
 
             return undefined // Allow access
 
@@ -372,9 +372,6 @@ export default class VFS {
             // After loop is finished, check if direct parent has write perms:
             if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
 
-            if (current.lock && (current.lock === 'pending' || current.lock.deref())) 
-                return new IBFSError('L2_VFS_LOCKED', `Can not rename this item because it's parent directory is currently in use.`, null, { path, group, lockPending: true })
-
             // Check if source item exists
             const srcNamedItem = current.children[dest]
             if (!srcNamedItem) return new IBFSError('L2_VFS_BAD_PATH', `Entry "${dest}" in "${path}" does not exist.`, null, { path, group })
@@ -382,6 +379,9 @@ export default class VFS {
             // Check if the target name isn't taken
             const destNamedItem = current.children[newName]
             if (destNamedItem) return new IBFSError('L2_VFS_ALREADY_EXISTS', `Entry "${newName}" in "${path}" already exists.`, null, { path, group })
+
+            if (current.lock && (current.lock === 'pending' || current.lock.deref())) 
+                return new IBFSError('L2_VFS_LOCKED', `Can not rename this item because it's parent directory is currently accessed elsewhere.`, null, { path, group, lockPending: true })
             
             return undefined // Allow access
             
@@ -404,7 +404,7 @@ export default class VFS {
      * result    -> /new/path/file.txt
      * ```
      */
-    public canMoveNode(path: string, newParent: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_MOVE_NODE' | 'L2_VFS_ALREADY_EXISTS'> {
+    public canMoveNode(path: string, newParent: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_MOVE_NODE' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean, lockedDir?: 'source' | 'dest' }> {
         try {
 
             let current = this.tree
@@ -437,6 +437,9 @@ export default class VFS {
             const sourceItem = current.children[srcFinal]
             if (!sourceItem) return new IBFSError('L2_VFS_BAD_PATH', `Entry "${srcFinal}" in "${path}" doesn't exists.`, null, { path, group })
 
+            if (current.lock && (current.lock === 'pending' || current.lock.deref())) 
+                return new IBFSError('L2_VFS_LOCKED', `Can not move this item because it's parent directory is currently accessed elsewhere.`, null, { path, group, lockPending: true, lockedDir: 'source' })
+
             // Destination path -----------------------------------------------
 
             current = this.tree
@@ -466,6 +469,9 @@ export default class VFS {
 
             const destItem = current.children[destFinal]
             if (destItem) return new IBFSError('L2_VFS_ALREADY_EXISTS', `Entry "${destFinal}" in "${newParent}" already exists.`, null, { path, group })
+
+            if (current.lock && (current.lock === 'pending' || current.lock.deref())) 
+                return new IBFSError('L2_VFS_LOCKED', `Can not move this item because the destination directory is currently accessed elsewhere.`, null, { path, group, lockPending: true, lockedDir: 'dest' })
 
             return undefined            
             

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -163,7 +163,7 @@ export default class VFS {
      * @param group Group that is creating the node.
      * @returns `undefined` if the node can be created, or an `IBFSError` if not.
      */
-    public canMakeNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_CAN_MAKE_NODE' | 'L2_VFS_LOCKED'> {
+    public canMakeNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_CAN_MAKE_NODE' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean }> {
         try {
         
             let current             = this.tree
@@ -193,6 +193,12 @@ export default class VFS {
 
             // After loop is finished, check if direct parent has write perms:
             if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
+
+            const lock = current.lock
+            if (lock) {
+                if (lock === 'pending') return new IBFSError('L2_VFS_LOCKED', `Can not create the item because its parent directory is being read/written to.`, null, { path, group, lockPending: true })
+                if (lock.deref())       return new IBFSError('L2_VFS_LOCKED', `Can not create the item because its parent directory is being read/written to..`, null, { path, group })
+            }
                 
             const newCurrent = current.children[dest]
             if (newCurrent) return new IBFSError('L2_VFS_ALREADY_EXISTS', `Entry "${dest}" in "${path}" already exists.`, null, { path, group })
@@ -211,7 +217,7 @@ export default class VFS {
      * @param group Group that is reading the node.
      * @returns `undefined` if the node can be read, or an `IBFSError` if not.
      */
-    public canReadNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_READ_NODE'> {
+    public canReadNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_READ_NODE' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean }> {
         try {
             
             let current             = this.tree
@@ -243,6 +249,14 @@ export default class VFS {
             if (newCurrent.type === 'DIR') {
                 perm.progress(newCurrent.perms[group])
                 if (!perm.canRead) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
+            }
+
+            const lock = newCurrent.lock
+            if (lock) {
+                // TODO: Read the "pending" lock state upstream and configure a retry within a second or two of the first read attempt
+                if (lock === 'pending') return new IBFSError('L2_VFS_LOCKED', `Can not read the item in the parent directory as it's currently in use.`, null, { path, group, lockPending: true })
+                const ref = lock.deref()
+                if (ref && ref.mode !== 'r') return new IBFSError('L2_VFS_LOCKED', `Can not read the item in the parent directory as it's currently in use.`, null, { path, group })
             }
 
             return undefined // Allow access

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -163,7 +163,7 @@ export default class VFS {
      * @param group Group that is creating the node.
      * @returns `undefined` if the node can be created, or an `IBFSError` if not.
      */
-    public canMakeNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_CAN_MAKE_NODE' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean }> {
+    public canMakeNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_CAN_MAKE_NODE' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: true }> {
         try {
         
             let current             = this.tree
@@ -217,7 +217,7 @@ export default class VFS {
      * @param group Group that is reading the node.
      * @returns `undefined` if the node can be read, or an `IBFSError` if not.
      */
-    public canReadNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_READ_NODE' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean }> {
+    public canReadNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_READ_NODE' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: true }> {
         try {
             
             let current             = this.tree
@@ -273,7 +273,7 @@ export default class VFS {
      * @param group Group that is writing the node.
      * @returns `undefined` if the node can be written, or an `IBFSError` if not.
      */
-    public canWriteNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_WRITE_NODE' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean, missingTarget?: boolean }> {
+    public canWriteNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_WRITE_NODE' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: true, missingTarget?: boolean }> {
         try {
         
             let current             = this.tree
@@ -341,7 +341,7 @@ export default class VFS {
      * result  -> /path-to/my/newFile.txt
      * ```
      */
-    public canRenameNode(path: string, newName: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_RENAME_NODE' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean }> {
+    public canRenameNode(path: string, newName: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_RENAME_NODE' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: true }> {
         try {
 
             let current             = this.tree
@@ -404,7 +404,7 @@ export default class VFS {
      * result    -> /new/path/file.txt
      * ```
      */
-    public canMoveNode(path: string, newParent: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_MOVE_NODE' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean, lockedDir?: 'source' | 'dest' }> {
+    public canMoveNode(path: string, newParent: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_MOVE_NODE' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: true, lockedDir?: 'source' | 'dest' }> {
         try {
 
             let current = this.tree

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -163,7 +163,7 @@ export default class VFS {
      * @param group Group that is creating the node.
      * @returns `undefined` if the node can be created, or an `IBFSError` if not.
      */
-    public canMakeNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_CAN_MAKE_NODE'> {
+    public canMakeNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_CAN_MAKE_NODE' | 'L2_VFS_LOCKED'> {
         try {
         
             let current             = this.tree
@@ -173,8 +173,10 @@ export default class VFS {
             if (!perm.canRead) return new IBFSError('L2_VFS_NO_PERM',  null, null, { path, group })
             if (!dest)         return new IBFSError('L2_VFS_BAD_PATH', `Can't create item on an empty path.`, null, { path, group })
 
-            for (const part of parts) {
+            for (let i = 0; i < parts.length; i++) {
                 
+                const part = parts[i]!
+                const last = i === parts.length - 1
                 const newCurrent = (current as TDirectory).children[part]
 
                 if (!newCurrent)               return new IBFSError('L2_VFS_BAD_PATH', `Entry "${part}" in "${path}" does not exist.`,     null, { path, group })
@@ -182,6 +184,8 @@ export default class VFS {
 
                 perm.progress(newCurrent.perms[group])
                 if (!perm.canRead) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
+                
+                if (last && newCurrent.lock) return new IBFSError('L2_VFS_LOCKED', 'Can not create the item in the parent directory. The parent is locked.', null, { path, group })
                     
                 current = newCurrent
                 

--- a/src/L2/VirtualFilesystem.ts
+++ b/src/L2/VirtualFilesystem.ts
@@ -273,7 +273,7 @@ export default class VFS {
      * @param group Group that is writing the node.
      * @returns `undefined` if the node can be written, or an `IBFSError` if not.
      */
-    public canWriteNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_WRITE_NODE', { path: string, group: string, missingTarget?: boolean }> {
+    public canWriteNode(path: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_WRITE_NODE' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean, missingTarget?: boolean }> {
         try {
         
             let current             = this.tree
@@ -314,6 +314,12 @@ export default class VFS {
                 if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
             }
 
+            const lock = newCurrent.lock
+            if (lock) {
+                if (lock === 'pending') return new IBFSError('L2_VFS_LOCKED', `Can not write the item because it's currently in use.`, null, { path, group, lockPending: true })
+                if (lock.deref())       return new IBFSError('L2_VFS_LOCKED', `Can not write the item because it's currently in use.`, null, { path, group })
+            }
+
             return undefined // Allow access
 
         } 
@@ -335,7 +341,7 @@ export default class VFS {
      * result  -> /path-to/my/newFile.txt
      * ```
      */
-    public canRenameNode(path: string, newName: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_RENAME_NODE' | 'L2_VFS_ALREADY_EXISTS'> {
+    public canRenameNode(path: string, newName: string, group: string): T.XEavS<'L2_VFS_BAD_PATH' | 'L2_VFS_NO_PERM' | 'L2_VFS_CAN_RENAME_NODE' | 'L2_VFS_ALREADY_EXISTS' | 'L2_VFS_LOCKED', { path: string, group: string, lockPending?: boolean }> {
         try {
 
             let current             = this.tree
@@ -365,6 +371,9 @@ export default class VFS {
 
             // After loop is finished, check if direct parent has write perms:
             if (!perm.canWrite) return new IBFSError('L2_VFS_NO_PERM', null, null, { path, group })
+
+            if (current.lock && (current.lock === 'pending' || current.lock.deref())) 
+                return new IBFSError('L2_VFS_LOCKED', `Can not rename this item because it's parent directory is currently in use.`, null, { path, group, lockPending: true })
 
             // Check if source item exists
             const srcNamedItem = current.children[dest]

--- a/src/errors/IBFSError.ts
+++ b/src/errors/IBFSError.ts
@@ -254,7 +254,7 @@ const errorCodes = {
     L2_VFS_CAN_MOVE_NODE:           'Can not move a node from the source directory to the target directory.',
     L2_VFS_CAN_DELETE_NODE:         'Can not delete a node.',
     L2_VFS_CAN_MANAGE_NODE:         'The group has no permission to manage this node.',
-    L2_VFS_LOCKED:                  'The location is currently locked because it is open elsewhere.',
+    L2_VFS_LOCKED:                  'The location is currently locked because it is open elsewhere. Wait and try in a moment.',
 
     L2_NS_CREATE:                   'Failed to create the filesystem namespace.',
     L2_NS_OPEN:                     'Failed to open the filesystem namespace.',

--- a/src/errors/IBFSError.ts
+++ b/src/errors/IBFSError.ts
@@ -254,6 +254,7 @@ const errorCodes = {
     L2_VFS_CAN_MOVE_NODE:           'Can not move a node from the source directory to the target directory.',
     L2_VFS_CAN_DELETE_NODE:         'Can not delete a node.',
     L2_VFS_CAN_MANAGE_NODE:         'The group has no permission to manage this node.',
+    L2_VFS_LOCKED:                  'The location is currently locked because it is open elsewhere.',
 
     L2_NS_CREATE:                   'Failed to create the filesystem namespace.',
     L2_NS_OPEN:                     'Failed to open the filesystem namespace.',

--- a/test/L2/namespace.test.ts
+++ b/test/L2/namespace.test.ts
@@ -63,7 +63,7 @@ describe('Namespace', () => {
 
     })
 
-    test('ns.open (create:true)', async () => {
+    test('ns.open (create:true) + write', async () => {
 
         const name = 'l2_open_create'
         const ns = await useEmptyNamespace(name)
@@ -77,8 +77,9 @@ describe('Namespace', () => {
 
         const data = crypto.randomBytes(20_000)
         await uniformSA(h1.writeFile(data))
+        const read = await uniformAsync(h1.readFile())
 
-        expect(await uniformAsync(h1.readFile())).toStrictEqual(data)
+        expect(read).toStrictEqual(data)
 
     })
 

--- a/test/L2/vfs.test.ts
+++ b/test/L2/vfs.test.ts
@@ -55,6 +55,12 @@ describe('Virtual Filesystem', () => {
                     },
                 },
             },
+            'locked-file': {
+                type: 'FILE',
+                size: 1400,
+                address: 10,
+                lock: 'pending',
+            }
         }
 
         // Root directory
@@ -77,6 +83,9 @@ describe('Virtual Filesystem', () => {
         // Nested folder whose parent has denied permissions
         expect(vfs.canReadNode('/folder1/folder2/folder3/', 'group1')).toBeInstanceOf(IBFSError)
         expect(vfs.canReadNode('/folder1/folder2/folder3/', 'group2')!.has('L2_VFS_NO_PERM')).toBe(true)
+
+        // Respect file locks
+        expect(vfs.canReadNode('/locked-file', 'group1')!.has('L2_VFS_LOCKED')).toBe(true)
 
     })
 
@@ -104,6 +113,12 @@ describe('Virtual Filesystem', () => {
                         lock: null,
                     }
                 }
+            },
+            'locked-file': {
+                type: 'FILE',
+                size: 1400,
+                address: 10,
+                lock: 'pending',
             }
         }
 
@@ -121,6 +136,10 @@ describe('Virtual Filesystem', () => {
 
         // Nested file with denied parent
         expect(vfs.canWriteNode('/folder1/file2.txt', 'group2')!.has('L2_VFS_NO_PERM')).toBe(true)
+
+        // Respect file locks
+        expect(vfs.canWriteNode('/locked-file', 'group1')!.has('L2_VFS_NO_PERM')).toBe(true)
+        expect(vfs.canWriteNode('/locked-file', 'group2')!.has('L2_VFS_LOCKED')).toBe(true)
 
     })
 
@@ -255,6 +274,21 @@ describe('Virtual Filesystem', () => {
                     }
                 }
             },
+            'locked-dir': {
+                type: 'DIR',
+                size: 1400,
+                address: 10,
+                lock: 'pending',
+                perms: {},
+                children: {
+                    'file2.txt': {
+                        type: 'FILE',
+                        size: 5000,
+                        address: 30,
+                        lock: null,
+                    }
+                }
+            }
         }
 
         // Rename root directory
@@ -270,6 +304,9 @@ describe('Virtual Filesystem', () => {
 
         // Rename to an already taken name
         expect(vfs.canRenameNode('file1.txt', 'folder1', 'group2')!.has('L2_VFS_ALREADY_EXISTS')).toBe(true)
+
+        // Respect file locks
+        expect(vfs.canRenameNode('/locked-dir/file2.txt', 'new-name', 'group2')!.has('L2_VFS_LOCKED')).toBe(true)
 
     })
 

--- a/test/L2/vfs.test.ts
+++ b/test/L2/vfs.test.ts
@@ -439,7 +439,22 @@ describe('Virtual Filesystem', () => {
                         lock: null,
                     }
                 }
-            }
+            },
+            'locked-dir': {
+                type: 'DIR',
+                size: 1400,
+                address: 10,
+                lock: null,
+                perms: {},
+                children: {
+                    'file2.txt': {
+                        type: 'FILE',
+                        size: 5000,
+                        address: 30,
+                        lock: 'pending'
+                    }
+                }
+            },
         }
 
         // Delete root directory
@@ -463,6 +478,9 @@ describe('Virtual Filesystem', () => {
         // Delete folder with children the user doesn't have write access to
         expect(vfs.canDeleteNode('/folder1', 'group2')!.has('L2_VFS_NO_PERM_NESTED')).toBe(true)
 
+        // Respect file locks
+        expect(vfs.canDeleteNode('/locked-dir/file2.txt', 'group2')!.has('L2_VFS_LOCKED')).toBe(true)
+        expect(vfs.canDeleteNode('/locked-dir',           'group2')!.has('L2_VFS_LOCKED')).toBe(true)
 
     })
 

--- a/test/L2/vfs.test.ts
+++ b/test/L2/vfs.test.ts
@@ -149,6 +149,14 @@ describe('Virtual Filesystem', () => {
                     }
                 }
             },
+            'folder2': {
+                type: 'DIR',
+                size: 0,
+                address: 40,
+                perms: {},
+                lock: 'pending',
+                children: {}
+            }
         }
 
         // Root directory
@@ -171,6 +179,9 @@ describe('Virtual Filesystem', () => {
         // Nested file with denied parent
         expect(vfs.canMakeNode('/folder1/file3.txt', 'group2')).toBe(undefined)
         expect(vfs.canMakeNode('/folder1/file3.txt', 'group3')!.has('L2_VFS_NO_PERM')).toBe(true)
+
+        // Respect the parent directory of the to-be-created node's parent directory.
+        expect(vfs.canMakeNode('/folder2/file.txt', 'group2')!.has('L2_VFS_LOCKED')).toBe(true)
 
 
     })

--- a/test/L2/vfs.test.ts
+++ b/test/L2/vfs.test.ts
@@ -1,7 +1,6 @@
 import { describe, test, expect } from "vitest"
 import IBFSError from "../../src/errors/IBFSError.js"
 import VFS from "../../src/L2/VirtualFilesystem.js"
-import { TPermLevel } from "../../src/L1/directory/DirectoryTables.js"
 
 describe('Virtual Filesystem', () => {
 
@@ -201,50 +200,6 @@ describe('Virtual Filesystem', () => {
 
         // Respect file locks
         expect(vfs.canMakeNode('/folder2/file.txt', 'group2')!.has('L2_VFS_LOCKED')).toBe(true)
-
-
-    })
-
-    test('VFS.canManageNode', () => {
-
-        vfs.tree.perms = { group1: 1, group2: 4, group3: 0 }
-        vfs.tree.children = {
-            'file1.txt': {
-                type: 'FILE',
-                size: 1400,
-                address: 10,
-                lock: null,
-            },
-            'folder1': {
-                type: 'DIR',
-                size: 0,
-                address: 20,
-                perms: { group1: 3, group3: 3 },
-                lock: null,
-                children: {
-                    'file2.txt': {
-                        type: 'FILE',
-                        size: 5000,
-                        address: 30,
-                        lock: null,
-                    }
-                }
-            },
-        }
-
-        // Manage root directory
-        expect(vfs.canManageNode('/', 'group1')!.has('L2_VFS_NO_PERM')).toBe(true)
-        expect(vfs.canManageNode('/', 'group2')).toBe(undefined)
-
-        // Manage direct children of a level-3 directory
-        expect(vfs.canManageNode('/folder1', 'group1')).toBe(undefined)
-        expect(vfs.canManageNode('/folder1/file2.txt', 'group2')!.has('L2_VFS_BAD_PATH')).toBe(true) // Can't manage files, only directories
-
-        expect(vfs.canManageNode('/folder1', 'group2')).toBe(undefined)
-
-        // Manage directory while upper parent denies access
-        expect(vfs.canManageNode('/folder1', 'group3')!.has('L2_VFS_NO_PERM')).toBe(true)
-        expect(vfs.canManageNode('/folder1/file2.txt', 'group3')!.has('L2_VFS_NO_PERM')).toBe(true)
 
 
     })
@@ -481,6 +436,50 @@ describe('Virtual Filesystem', () => {
         // Respect file locks
         expect(vfs.canDeleteNode('/locked-dir/file2.txt', 'group2')!.has('L2_VFS_LOCKED')).toBe(true)
         expect(vfs.canDeleteNode('/locked-dir',           'group2')!.has('L2_VFS_LOCKED')).toBe(true)
+
+    })
+
+    test('VFS.canManageNode', () => {
+
+        vfs.tree.perms = { group1: 1, group2: 4, group3: 0 }
+        vfs.tree.children = {
+            'file1.txt': {
+                type: 'FILE',
+                size: 1400,
+                address: 10,
+                lock: null,
+            },
+            'folder1': {
+                type: 'DIR',
+                size: 0,
+                address: 20,
+                perms: { group1: 3, group3: 3 },
+                lock: null,
+                children: {
+                    'file2.txt': {
+                        type: 'FILE',
+                        size: 5000,
+                        address: 30,
+                        lock: null,
+                    }
+                }
+            },
+        }
+
+        // Manage root directory
+        expect(vfs.canManageNode('/', 'group1')!.has('L2_VFS_NO_PERM')).toBe(true)
+        expect(vfs.canManageNode('/', 'group2')).toBe(undefined)
+
+        // Manage direct children of a level-3 directory
+        expect(vfs.canManageNode('/folder1', 'group1')).toBe(undefined)
+        expect(vfs.canManageNode('/folder1/file2.txt', 'group2')!.has('L2_VFS_BAD_PATH')).toBe(true) // Can't manage files, only directories
+
+        expect(vfs.canManageNode('/folder1', 'group2')).toBe(undefined)
+
+        // Manage directory while upper parent denies access
+        expect(vfs.canManageNode('/folder1', 'group3')!.has('L2_VFS_NO_PERM')).toBe(true)
+        expect(vfs.canManageNode('/folder1/file2.txt', 'group3')!.has('L2_VFS_NO_PERM')).toBe(true)
+
 
     })
 

--- a/test/L2/vfs.test.ts
+++ b/test/L2/vfs.test.ts
@@ -199,7 +199,7 @@ describe('Virtual Filesystem', () => {
         expect(vfs.canMakeNode('/folder1/file3.txt', 'group2')).toBe(undefined)
         expect(vfs.canMakeNode('/folder1/file3.txt', 'group3')!.has('L2_VFS_NO_PERM')).toBe(true)
 
-        // Respect the parent directory of the to-be-created node's parent directory.
+        // Respect file locks
         expect(vfs.canMakeNode('/folder2/file.txt', 'group2')!.has('L2_VFS_LOCKED')).toBe(true)
 
 
@@ -361,7 +361,22 @@ describe('Virtual Filesystem', () => {
                         lock: null,
                     }
                 }
-            }
+            },
+            'locked-dir': {
+                type: 'DIR',
+                size: 1400,
+                address: 10,
+                lock: 'pending',
+                perms: {},
+                children: {
+                    'file2.txt': {
+                        type: 'FILE',
+                        size: 5000,
+                        address: 30,
+                        lock: null,
+                    }
+                }
+            },
         }
 
         // Move root directory
@@ -378,6 +393,17 @@ describe('Virtual Filesystem', () => {
 
         // Move item to a directory with an item of the same name
         expect(vfs.canMoveNode('/folder1/file4.txt', '/folder2', 'group2')!.has('L2_VFS_ALREADY_EXISTS')).toBe(true)
+
+        // Respect file locks
+        const op1 = vfs.canMoveNode('/file1.txt', '/locked-dir/', 'group2')!
+        expect(op1.has('L2_VFS_LOCKED')).toBe(true)
+        expect(op1.meta.lockPending).toBe(true)
+        expect(op1.meta.lockedDir).toBe('dest')
+
+        const op2 = vfs.canMoveNode('/locked-dir/file2.txt', '/folder2', 'group2')!
+        expect(op2.has('L2_VFS_LOCKED')).toBe(true)
+        expect(op2.meta.lockPending).toBe(true)
+        expect(op2.meta.lockedDir).toBe('source')
 
     })
 


### PR DESCRIPTION
- VFS class methods now respect pending and active locks represented in the virtual filesystem tree.
- NS.open now retries to open in read-only mode when it encounters a pending lock in the VFS.